### PR TITLE
make submodules use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = https://github.com/DaveGamble/cJSON.git
 [submodule "cspot/cpp-reflection"]
 	path = cspot/cpp-reflection
-	url = git@github.com:alufers/cpp-reflection.git
+	url = https://github.com/alufers/cpp-reflection.git


### PR DESCRIPTION
the `cpp-reflection` submodule was using ssh, which prevents cloning for users without github accounts (or in the provided Docker build file). This patch makes all of the submodules use https.