### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,11 +3,9 @@ FROM ubuntu:focal AS builder
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
  && apt-get install --no-install-recommends -y \
-    git python3 python3-pip \
+    git ca-certificates golang protobuf-compiler \
     libavahi-compat-libdnssd-dev libasound2-dev libasound2-plugins \
     cmake build-essential libssl-dev
-
-RUN pip3 install protobuf grpcio-tools
 
 WORKDIR /src
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   cspot-pulse:
     build: .
-    container_name: cspot
+    container_name: cspot-pulse
     restart: always
     network_mode: host
     volumes:
@@ -19,7 +19,7 @@ services:
   cspot-alsa:
     # someone test pls
     build: .
-    container_name: cspot
+    container_name: cspot-alsa
     restart: always
     network_mode: host
     volumes:


### PR DESCRIPTION
Running the existing Dockerfile through docker-compose with `docker-compose up --build` failed, likely due to a change in how protos are generated now compared to when the file was added?
This command now succeeds in building the binary (though subsequently fails to mount `/dev/snd` on a MacOS host, but that's a separate issue).