### PR TITLE
Initial platformio support

### DIFF
--- a/targets/esp32/CMakeLists.txt
+++ b/targets/esp32/CMakeLists.txt
@@ -1,6 +1,10 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
+# Don't override EXTRA_COMPONENT_DIRS as platformio uses it.  Instead we append
+# see https://github.com/platformio/platform-espressif32/issues/341
+list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(cspot-esp32)

--- a/targets/esp32/boards/esp-wrover-b-3.3v.json
+++ b/targets/esp32/boards/esp-wrover-b-3.3v.json
@@ -1,0 +1,52 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "hwids": [
+      [
+        "0x0403",
+        "0x6010"
+      ]
+    ],
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "default_tool": "ftdi",
+    "onboard_tools": [
+      "ftdi"
+    ],
+    "openocd_board": "esp32-wrover-kit-3.3v.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP-WROVER kit 3.3v",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "protocols": [
+      "esptool",
+      "espota",
+      "ftdi"
+    ],
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://espressif.com/en/products/hardware/esp-wrover-kit/overview",
+  "vendor": "Espressif"
+}

--- a/targets/esp32/platformio.ini
+++ b/targets/esp32/platformio.ini
@@ -1,0 +1,40 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = main
+
+[env:cspot-wrover-b]
+platform = espressif32
+
+# WROVER-B uses 3.3v flash
+board = esp-wrover-b-3.3v
+
+framework = espidf
+build_flags =
+    -DCONFIG_SPIRAM_CACHE_WORKAROUND    # Not sure if this is necessary for WROVER-B
+board_build.partitions = partitions.csv
+
+# Set the serial monitor port for your system 
+monitor_port = /dev/ttyUSB2
+monitor_speed = 115200
+
+# Uncomment the following lines to enable JTAG debbugging and flashing using an FT2232
+# see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/configure-ft2232h-jtag.html
+# Wiring:
+# ESP32-WROVER      FT2232
+#       GND         GND
+#       IO12        AD1
+#       IO13        AD0
+#       IO14        AD3
+#       IO15        AD2
+#       EN          AD4
+debug_tool = ftdi
+upload_protocol = ftdi


### PR DESCRIPTION
You can now use VSCode platformio with esp-idf extension installed as the IDE for cspot development.

CMakeLists.txt has been changed to make it compatible with platformio while maintaining support for command-line idf development builds: "idf.py build".

WROVER-B build support is implemented in platformio.ini

JTAG debugging and upload using FT2232 are also supported.
