### PR TITLE
Add command line bitrate option

### DIFF
--- a/targets/cli/CommandLineArguments.cpp
+++ b/targets/cli/CommandLineArguments.cpp
@@ -1,4 +1,5 @@
 #include "CommandLineArguments.h"
+#include "ProtoHelper.h"
 
 CommandLineArguments::CommandLineArguments(std::string u, std::string p, bool shouldShowHelp) : username(u), password(p), shouldShowHelp(shouldShowHelp) {}
 
@@ -38,6 +39,31 @@ std::shared_ptr<CommandLineArguments> CommandLineArguments::parse(int argc, char
                 throw std::invalid_argument("expected path after the password flag");
             }
             result->password = std::string(argv[++i]);
+        }
+        else if (stringVal == "-b" || stringVal == "--bitrate")
+        {
+            if (i >= argc - 1)
+            {
+                throw std::invalid_argument("expected path after the bitrate flag");
+            }
+            i++;
+            if(std::string(argv[i]) == "320")
+            {
+              result->bitrate = AudioFormat::OGG_VORBIS_320;
+            }
+            else if(std::string(argv[i]) == "160")
+            {
+              result->bitrate = AudioFormat::OGG_VORBIS_160;
+            }
+            else if(std::string(argv[i]) == "96")
+            {
+              result->bitrate = AudioFormat::OGG_VORBIS_96;
+            }
+            else
+            {
+              throw std::invalid_argument("invalid bitrate argument");
+            }
+            result->setBitrate = true;
         }
         else
         {

--- a/targets/cli/CommandLineArguments.h
+++ b/targets/cli/CommandLineArguments.h
@@ -3,9 +3,10 @@
 #include <string>
 #include <memory>
 #include <stdexcept>
+#include "ProtoHelper.h"
 /**
  * Represents the command line arguments passed to the program.
- * 
+ *
  */
 class CommandLineArguments
 {
@@ -15,9 +16,14 @@ public:
      */
     std::string username;
     /**
-         * The spotify password.
-         */
+     * The spotify password.
+    */
     std::string password;
+    /**
+     * Bitrate setting.
+    */
+    bool setBitrate = false;
+    AudioFormat bitrate;
     /**
      * Determines whether the help text should be printed.
      */


### PR DESCRIPTION
Bitrate now can be easly set on both targets. On esp32 by adjusting config variables and on cli by command line arguments.
I think #11 can be closed.

(also restored if statement checking username arg that was accidentally removed :laughing: ) 