### PR TITLE
Fixed segmentation fault issue, on seeking songs.

### DIFF
--- a/cspot/src/ChunkedAudioStream.cpp
+++ b/cspot/src/ChunkedAudioStream.cpp
@@ -211,8 +211,13 @@ READ:
             {
                 if (chunk->decryptedData.size() - offset >= toRead)
                 {
-                    res.insert(res.end(), chunk->decryptedData.begin() + offset, chunk->decryptedData.begin() + offset + toRead);
-                    this->pos += toRead;
+                    if((chunk->decryptedData.begin() + offset) < chunk->decryptedData.end()) {
+                        res.insert(res.end(), chunk->decryptedData.begin() + offset,
+                                    chunk->decryptedData.begin() + offset + toRead);
+                        this->pos += toRead;
+                    } else {
+                        chunk->decrypt();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This issue happens on songs seeking or changing Spotify device from others to CSpot. And cause is emptiness of decryptedData part of the chunk.