### PR TITLE
bring back esp32 in cspot/euphonium

### DIFF
--- a/cspot/src/AudioChunkManager.cpp
+++ b/cspot/src/AudioChunkManager.cpp
@@ -49,7 +49,7 @@ void AudioChunkManager::runTask() {
     std::scoped_lock lock(this->runningMutex);
     while (isRunning) {
         std::pair<std::vector<uint8_t>, bool> audioPair;
-        if (this->audioChunkDataQueue.wtpop(audioPair, 10)) {
+        if (this->audioChunkDataQueue.wtpop(audioPair, 100)) {
             auto data = audioPair.first;
             auto failed = audioPair.second;
             uint16_t seqId = ntohs(extract<uint16_t>(data, 0));

--- a/cspot/src/ChunkedAudioStream.cpp
+++ b/cspot/src/ChunkedAudioStream.cpp
@@ -54,7 +54,7 @@ ChunkedAudioStream::ChunkedAudioStream(std::vector<uint8_t> fileId, std::vector<
     // File size is required for this packet to be downloaded
     this->fetchTraillingPacket();
 
-    vorbisFile = {0};
+    vorbisFile = { };
     vorbisCallbacks =
         {
             (decltype(ov_callbacks::read_func)) & vorbisReadCb,

--- a/targets/esp32/components/cspot/CMakeLists.txt
+++ b/targets/esp32/components/cspot/CMakeLists.txt
@@ -1,5 +1,8 @@
 idf_component_register(INCLUDE_DIRS "." PRIV_REQUIRES idf::mbedtls)
 
 add_definitions(-DCSPOT_USE_MBEDTLS)
+# set(BELL_DISABLE_CODECS 1)
+# set(BELL_DISABLE_TREMOR 1)
+# set(BELL_DISABLE_CJSON 1)
 add_subdirectory(../../../../cspot bindir)
 target_link_libraries(${COMPONENT_LIB} INTERFACE cspot)

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -32,9 +32,9 @@
 #include "Logger.h"
 
 // Config sink
-#define AC101 // INTERNAL, AC101, ES8018, PCM5102
+#define PCM5102 // INTERNAL, AC101, ES8018, PCM5102
 #define QUALITY     320      // 320, 160, 96
-#define DEVICE_NAME "CSpot"
+#define DEVICE_NAME "CSpot-ESP32"
 
 #ifdef INTERNAL
 #include <InternalAudioSink.h>
@@ -51,7 +51,12 @@
 
 static const char *TAG = "cspot";
 
+std::shared_ptr<ESPFile> file;
+std::shared_ptr<MercuryManager> mercuryManager;
+std::shared_ptr<SpircController> spircController;
 std::shared_ptr<ConfigJSON> configMan;
+std::string credentialsFileName = "/spiffs/authBlob.json";
+bool createdFromZeroconf = false;
 
 extern "C"
 {
@@ -59,16 +64,17 @@ extern "C"
 }
 static void cspotTask(void *pvParameters)
 {
-    auto zeroconfAuthenticator = std::make_shared<ZeroconfAuthenticator>();
+	
+    bell::setDefaultLogger();
 
-    // Config file
-    auto file = std::make_shared<ESPFile>();
-    configMan = std::make_shared<ConfigJSON>("/spiffs/config.json", file);
+	// Config file
+	file = std::make_shared<ESPFile>();
+	configMan = std::make_shared<ConfigJSON>("/spiffs/config.json", file);
 
-    if(!configMan->load())
-    {
-      CSPOT_LOG(error, "Config error");
-    }
+	if(!configMan->load())
+	{
+		CSPOT_LOG(error, "Config error");
+	}
 
     configMan->deviceName = DEVICE_NAME;
 
@@ -78,57 +84,70 @@ static void cspotTask(void *pvParameters)
     configMan->format = AudioFormat::OGG_VORBIS_160;
 #else
     configMan->format = AudioFormat::OGG_VORBIS_96;
+#endif		
+
+    auto createPlayerCallback = [](std::shared_ptr<LoginBlob> blob) {
+        CSPOT_LOG(info, "Creating player");
+        auto session = std::make_unique<Session>();
+        session->connectWithRandomAp();
+        auto token = session->authenticate(blob);
+
+        // Auth successful
+        if (token.size() > 0)
+        {
+			if (createdFromZeroconf) {
+                file->writeFile(credentialsFileName, blob->toJson());
+            }
+#ifdef INTERNAL
+			auto audioSink = std::make_shared<InternalAudioSink>();
+#endif
+#ifdef AC101
+			auto audioSink = std::make_shared<AC101AudioSink>();
+#endif
+#ifdef ES8018
+			auto audioSink = std::make_shared<ES9018AudioSink>();
+#endif
+#ifdef PCM5102
+			auto audioSink = std::make_shared<PCM5102AudioSink>();
 #endif
 
+            // @TODO Actually store this token somewhere
+            mercuryManager = std::make_shared<MercuryManager>(std::move(session));
+
+            mercuryManager->startTask();
+
+            spircController = std::make_shared<SpircController>(mercuryManager, blob->username, audioSink);
+            mercuryManager->reconnectedCallback = []() {
+                return spircController->subscribe();
+            };
+
+            mercuryManager->handleQueue();
+        }
+
+    };
+
     // Blob file
-    std::string credentialsFileName = "/spiffs/authBlob.json";
     std::shared_ptr<LoginBlob> blob;
     std::string jsonData;
 
     bool read_status = file->readFile(credentialsFileName, jsonData);
 
-    if(jsonData.length() > 0 && read_status)
+	if (jsonData.length() > 0 && read_status)
     {
-      blob = std::make_shared<LoginBlob>();
-      blob->loadJson(jsonData);
+        blob = std::make_shared<LoginBlob>();
+        blob->loadJson(jsonData);
+        createPlayerCallback(blob);
     }
+    // ZeroconfAuthenticator
     else
     {
-      auto authenticator = std::make_shared<ZeroconfAuthenticator>();
-      blob = authenticator->listenForRequests();
-      file->writeFile(credentialsFileName, blob->toJson());
+        createdFromZeroconf = true;
+        auto authenticator = std::make_shared<ZeroconfAuthenticator>(createPlayerCallback);
+        authenticator->listenForRequests();
     }
 
-    auto session = std::make_unique<Session>();
-    session->connectWithRandomAp();
-    auto token = session->authenticate(blob);
+	vTaskSuspend(NULL);
 
-    // Auth successful
-    if (token.size() > 0)
-    {
-        // @TODO Actually store this token somewhere
-        auto mercuryManager = std::make_shared<MercuryManager>(std::move(session));
-        mercuryManager->startTask();
-
-#ifdef INTERNAL
-        auto audioSink = std::make_shared<InternalAudioSink>();
-#endif
-#ifdef AC101
-        auto audioSink = std::make_shared<AC101AudioSink>();
-#endif
-#ifdef ES8018
-        auto audioSink = std::make_shared<ES9018AudioSink>();
-#endif
-#ifdef PCM5102
-        auto audioSink = std::make_shared<PCM5102AudioSink>();
-#endif
-
-        auto spircController = std::make_shared<SpircController>(mercuryManager, blob->username, audioSink);
-        mercuryManager->reconnectedCallback = [spircController]() {
-            return spircController->subscribe();
-        };
-        mercuryManager->handleQueue();
-    }
 }
 
 void init_spiffs()
@@ -141,7 +160,6 @@ void init_spiffs()
     };
 
     esp_err_t ret = esp_vfs_spiffs_register(&conf);
-    setDefaultLogger();
 
     if (ret != ESP_OK)
     {
@@ -190,7 +208,6 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     ESP_ERROR_CHECK(example_connect());
 
-    ESP_LOGI("TAG", "Connected to AP, start spotify receiver");
-    // for(;;);
+    ESP_LOGI(TAG, "Connected to AP, start spotify receiver");
     auto taskHandle = xTaskCreatePinnedToCore(&cspotTask, "cspot", 8192 * 8, NULL, 5, NULL, 0);
 }


### PR DESCRIPTION
This makes the main.cpp work again in esp32 and the audichunk timeout to a lock set at 10ms was causing FreeRTOS to be stuck in that loop. 100 is fine but maybe it's still a bit low (I think it was a no timeout lock before, but I assume you want a way out of that loop)