### PR TITLE
mDNS initialization should be done by "central" services

### DIFF
--- a/cspot/src/ApResolve.cpp
+++ b/cspot/src/ApResolve.cpp
@@ -76,6 +76,8 @@ std::string ApResolve::getApList()
         jsonData += cur;
     }
 
+	close(sockFd);
+
     return jsonData;
 }
 

--- a/cspot/src/MercuryManager.cpp
+++ b/cspot/src/MercuryManager.cpp
@@ -162,8 +162,8 @@ void MercuryManager::runTask()
         catch (const std::runtime_error& e)
         {
             // Reconnection required
-            this->reconnect();
-            this->reconnectedCallback();
+            if (isRunning) this->reconnect();
+            if (isRunning) this->reconnectedCallback();
             continue;
         }
         if (static_cast<MercuryType>(packet->command) == MercuryType::PING) // @TODO: Handle time synchronization through ping

--- a/cspot/src/ZeroconfAuthenticator.cpp
+++ b/cspot/src/ZeroconfAuthenticator.cpp
@@ -59,8 +59,6 @@ void ZeroconfAuthenticator::registerZeroconf()
     const char* service = "_spotify-connect._tcp";
 
 #ifdef ESP_PLATFORM
-    mdns_init();
-    mdns_hostname_set("cspot");
     mdns_txt_item_t serviceTxtData[3] = {
         {"VERSION", "1.0"},
         {"CPath", "/spotify_info"},


### PR DESCRIPTION
Don't know if you will agree with this one, but I don't think (and it's a problem for squeezeESP32) that mDNS should be initialize dby cspot. It should be the job of the system's host/central service to do it