### PR TITLE
fix stop/updatequeue concurrency issues

### DIFF
--- a/cspot/include/MercuryManager.h
+++ b/cspot/include/MercuryManager.h
@@ -59,6 +59,7 @@ private:
   std::map<uint64_t, mercuryCallback> callbacks;
   std::mutex reconnectionMutex;
   std::mutex runningMutex;
+  std::mutex stopMutex;
   std::map<std::string, mercuryCallback> subscriptions;
   std::unique_ptr<Session> session;
   std::shared_ptr<LoginBlob> lastAuthBlob; 

--- a/cspot/src/AudioChunkManager.cpp
+++ b/cspot/src/AudioChunkManager.cpp
@@ -46,7 +46,7 @@ void AudioChunkManager::close() {
 
 void AudioChunkManager::runTask() {
     std::scoped_lock lock(this->runningMutex);
-	this->isRunning = true;
+    this->isRunning = true;
     while (isRunning) {
         std::pair<std::vector<uint8_t>, bool> audioPair;
         if (this->audioChunkDataQueue.wtpop(audioPair, 100)) {

--- a/cspot/src/AudioChunkManager.cpp
+++ b/cspot/src/AudioChunkManager.cpp
@@ -45,8 +45,8 @@ void AudioChunkManager::close() {
 }
 
 void AudioChunkManager::runTask() {
-    this->isRunning = true;
     std::scoped_lock lock(this->runningMutex);
+	this->isRunning = true;
     while (isRunning) {
         std::pair<std::vector<uint8_t>, bool> audioPair;
         if (this->audioChunkDataQueue.wtpop(audioPair, 100)) {

--- a/cspot/src/SpircController.cpp
+++ b/cspot/src/SpircController.cpp
@@ -38,7 +38,7 @@ void SpircController::subscribe() {
 }
 
 void SpircController::setPause(bool isPaused, bool notifyPlayer) {
-	sendEvent(CSpotEventType::PLAY_PAUSE, isPaused);
+    sendEvent(CSpotEventType::PLAY_PAUSE, isPaused);
     if (isPaused) {
         CSPOT_LOG(debug, "External pause command");
         if (notifyPlayer) player->pause();
@@ -55,29 +55,29 @@ void SpircController::disconnect(void) {
     player->cancelCurrentTrack();
     state->setActive(false);
     notify();
-	// Send the event at the end at it might be a last gasp
-	sendEvent(CSpotEventType::DISC);	
+    // Send the event at the end at it might be a last gasp
+    sendEvent(CSpotEventType::DISC);    
 }
 
 void SpircController::playToggle() {
-	if (state->innerFrame.state->status.value() == PlayStatus::kPlayStatusPause) {
-		setPause(false);
-	} else {
-		setPause(true);
-	}
+    if (state->innerFrame.state->status.value() == PlayStatus::kPlayStatusPause) {
+        setPause(false);
+    } else {
+        setPause(true);
+    }
 }
 
 void SpircController::adjustVolume(int by) {
-	if (state->innerFrame.device_state->volume.has_value()) {
-		int volume = state->innerFrame.device_state->volume.value() + by;
-		if (volume < 0) volume = 0;
-		else if (volume > MAX_VOLUME) volume = MAX_VOLUME;
-		setVolume(volume);
-	}
+    if (state->innerFrame.device_state->volume.has_value()) {
+        int volume = state->innerFrame.device_state->volume.value() + by;
+        if (volume < 0) volume = 0;
+        else if (volume > MAX_VOLUME) volume = MAX_VOLUME;
+        setVolume(volume);
+    }
 }
 
 void SpircController::setVolume(int volume) {
-	setRemoteVolume(volume);
+    setRemoteVolume(volume);
     player->setVolume(volume);
     configMan->save();
 }
@@ -111,21 +111,21 @@ void SpircController::handleFrame(std::vector<uint8_t> &data) {
         // Pause the playback if another player took control
         if (state->isActive() &&
             state->remoteFrame.device_state->is_active.value()) {
-			disconnect();
+            disconnect();
         }
         break;
     }
     case MessageType::kMessageTypeSeek: {
         CSPOT_LOG(debug, "Seek command");
-		sendEvent(CSpotEventType::SEEK, (int) state->remoteFrame.position.value());
+        sendEvent(CSpotEventType::SEEK, (int) state->remoteFrame.position.value());
         state->updatePositionMs(state->remoteFrame.position.value());
         this->player->seekMs(state->remoteFrame.position.value());
         notify();
         break;
     }
     case MessageType::kMessageTypeVolume:
-		sendEvent(CSpotEventType::VOLUME, (int) state->remoteFrame.volume.value());
-		setVolume(state->remoteFrame.volume.value());
+        sendEvent(CSpotEventType::VOLUME, (int) state->remoteFrame.volume.value());
+        setVolume(state->remoteFrame.volume.value());
         break;
     case MessageType::kMessageTypePause:
         setPause(true);
@@ -134,11 +134,11 @@ void SpircController::handleFrame(std::vector<uint8_t> &data) {
         setPause(false);
         break;
     case MessageType::kMessageTypeNext:
-		sendEvent(CSpotEventType::NEXT);
+        sendEvent(CSpotEventType::NEXT);
         nextSong();
         break;
     case MessageType::kMessageTypePrev:
-		sendEvent(CSpotEventType::PREV);
+        sendEvent(CSpotEventType::PREV);
         prevSong();
         break;
     case MessageType::kMessageTypeLoad: {
@@ -182,7 +182,7 @@ void SpircController::handleFrame(std::vector<uint8_t> &data) {
 }
 
 void SpircController::loadTrack(uint32_t position_ms, bool isPaused) {
-	sendEvent(CSpotEventType::LOAD, (int) position_ms);
+    sendEvent(CSpotEventType::LOAD, (int) position_ms);
     state->setPlaybackState(PlaybackState::Loading);
     std::function<void()> loadedLambda = [=]() {
         // Loading finished, notify that playback started
@@ -201,7 +201,7 @@ void SpircController::sendEvent(CSpotEventType eventType, std::variant<TrackInfo
     if (eventHandler != nullptr) {
         CSpotEvent event = {
             .eventType = eventType,
-			.data = data,
+            .data = data,
         };
 
         eventHandler(event);
@@ -217,8 +217,8 @@ void SpircController::setEventHandler(cspotEventHandler callback) {
             info.artist = track.artist;
             info.imageUrl = track.imageUrl;
             info.name = track.name;
-			info.duration = track.duration;
-			this->sendEvent(CSpotEventType::TRACK_INFO, info);
+            info.duration = track.duration;
+            this->sendEvent(CSpotEventType::TRACK_INFO, info);
     });
 }
 

--- a/cspot/src/SpircController.cpp
+++ b/cspot/src/SpircController.cpp
@@ -55,7 +55,8 @@ void SpircController::disconnect(void) {
     player->cancelCurrentTrack();
     state->setActive(false);
     notify();
-	sendEvent(CSpotEventType::DISC);
+	// Send the event at the end at it might be a last gasp
+	sendEvent(CSpotEventType::DISC);	
 }
 
 void SpircController::playToggle() {


### PR DESCRIPTION
I did not realize but when I opened up the possibility for another thread to stop mercuryManager, it was a bit a "all hell breaks loose" situation.

Normally, mercuryManager::updateQueue receive the request from Spotify to disconnect/change players, it calls spircController::disconnect that emits a "DISC" event. The event handler might decide to call mercuryManager::stop. As a result, we exit updateQueue and later we can release the mercuryManager and spircController objects. It's all good because stop() is called by updateQueue(), so we won't leave updateQueue() until stop() has finished, so we have no risk to delete the mercuryManager (and it's runningMutex) while stop() still needs it.

I guess you see it coming: when spircController::disconnect() is called by another thread, then the DISC event handler will still call mercuryManager::stop() but that will release updateQueue (when isRunning is false). Depending on thread priorities, updateQueue might be called (and exited) while still in mercuryManager::stop(). As a result, we end up releasing mercuryManager (and spircController) while still in stop() and mercuryManager::runningMutex is non-existing.

So that PR simply makes sure that we can't exit updateQueue until stop has been finished, making sure things ar eorders properly, regardless of tasks's priorities (that could have been fixes this way, but that seems to me like a very bad idea).

Maybe you have a better idea how to make that work w/o adding yet another mutex, but I don't.

NB: I removed in mercuryManager::stop the RAII on audioChunkManager::runningMutex because I really don't see why it is needed as audioChunkManager::close() has already solved the issue