### PR TITLE
Fix build on linux with ALSA

### DIFF
--- a/cspot/src/Shannon.cpp
+++ b/cspot/src/Shannon.cpp
@@ -5,6 +5,8 @@
 // #define NDEBUG
 #include <assert.h>
 
+using std::size_t;
+
 static inline uint32_t rotl(uint32_t n, unsigned int c)
 {
     const unsigned int mask = (CHAR_BIT * sizeof(n) - 1); // assumes width is a power of 2.

--- a/targets/cli/ALSAAudioSink.cpp
+++ b/targets/cli/ALSAAudioSink.cpp
@@ -2,7 +2,7 @@
 
 #ifdef CSPOT_ENABLE_ALSA_SINK
 
-ALSAAudioSink::ALSAAudioSink() : Task(0, "", 0)
+ALSAAudioSink::ALSAAudioSink() : Task("", 0, 0, 0)
 {
     /* Open the PCM device in playback mode */
     if (pcm = snd_pcm_open(&pcm_handle, PCM_DEVICE,


### PR DESCRIPTION
Thanks for an awesome project. With the below changes this works really well on Linux for me.

The version of GCC I have on Linux required that `std:size_t` is properly namespaced and it looks as though the bell submodule was updated but the ALSA driver wasn't.