### PR TITLE
support for ES8388 DAC chip

### DIFF
--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -35,7 +35,7 @@
 #include "mdns.h"
 
 // Config sink
-#define PCM5102 // INTERNAL, AC101, ES8018, PCM5102
+#define PCM5102 // INTERNAL, AC101, ES8018, ES8388, PCM5102
 #define QUALITY     320      // 320, 160, 96
 #define DEVICE_NAME "CSpot-ESP32"
 
@@ -47,6 +47,9 @@
 #endif
 #ifdef ES8018
 #include <ES9018AudioSink.h>
+#endif
+#ifdef ES8388
+#include <ES388AudioSink.h>
 #endif
 #ifdef PCM5102
 #include <PCM5102AudioSink.h>
@@ -112,6 +115,9 @@ static void cspotTask(void *pvParameters)
 #endif
 #ifdef ES8018
 			auto audioSink = std::make_shared<ES9018AudioSink>();
+#endif
+#ifdef ES8388
+			auto audioSink = std::make_shared<ES8388AudioSink>();
 #endif
 #ifdef PCM5102
 			auto audioSink = std::make_shared<PCM5102AudioSink>();

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -49,7 +49,7 @@
 #include <ES9018AudioSink.h>
 #endif
 #ifdef ES8388
-#include <ES388AudioSink.h>
+#include <ES8388AudioSink.h>
 #endif
 #ifdef PCM5102
 #include <PCM5102AudioSink.h>

--- a/targets/esp32/main/sinks/ES8388AudioSink.cpp
+++ b/targets/esp32/main/sinks/ES8388AudioSink.cpp
@@ -1,0 +1,155 @@
+#include "ES8388AudioSink.h"
+
+struct es8388_cmd_s {
+    uint8_t reg;
+    uint8_t value;
+};
+
+ES8388AudioSink::ES8388AudioSink()
+{
+    // configure i2c
+    i2c_config = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = 33,
+        .scl_io_num = 32,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+    };
+
+    i2c_config.master.clk_speed = 100000;
+
+    i2s_config_t i2s_config = {
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX), // Only TX
+        .sample_rate = 44100,
+        .bits_per_sample = (i2s_bits_per_sample_t)16,
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT, //2-channels
+        .communication_format = (i2s_comm_format_t)I2S_COMM_FORMAT_STAND_MSB,
+        .intr_alloc_flags = 0, //Default interrupt priority
+        .dma_buf_count = 8,
+        .dma_buf_len = 512,
+        .use_apll = true,
+        .tx_desc_auto_clear = true, //Auto clear tx descriptor on underflow
+        .fixed_mclk = 256 * 44100
+    };
+
+    i2s_pin_config_t pin_config = {
+        .bck_io_num = 27,
+        .ws_io_num = 25,
+        .data_out_num = 26,
+        .data_in_num = -1 //Not used
+    };
+
+    int err;
+
+    err = i2s_driver_install((i2s_port_t)0, &i2s_config, 0, NULL);
+    if (err != ESP_OK) {
+        ESP_LOGE("OI", "i2s driver installation error: %d", err);
+    }
+
+    err = i2s_set_pin((i2s_port_t)0, &pin_config);
+    if (err != ESP_OK) {
+        ESP_LOGE("OI", "i2s set pin error: %d", err);
+    }
+
+    PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+    REG_SET_FIELD(PIN_CTRL, CLK_OUT1, 0);
+    ESP_LOGI("OI", "MCLK output on CLK_OUT1");
+
+
+    err = i2c_param_config(0, &i2c_config);
+    if (err != ESP_OK) {
+        ESP_LOGE("OI", "i2c param config error: %d", err);
+    }
+    
+    err = i2c_driver_install(0, I2C_MODE_MASTER, 0, 0, 0);
+    if (err != ESP_OK) {
+        ESP_LOGE("OI", "i2c driver installation error: %d", err);
+    }
+
+    i2c_cmd_handle_t i2c_cmd = i2c_cmd_link_create();
+
+    err = i2c_master_start(i2c_cmd);
+    if (err != ESP_OK) {
+        ESP_LOGE("OI", "i2c master start error: %d", err);
+    }
+
+    /* mute DAC during setup, power up all systems, slave mode */
+    writeReg(ES8388_DACCONTROL3, 0x04);
+    writeReg(ES8388_CONTROL2, 0x50);
+    writeReg(ES8388_CHIPPOWER, 0x00);
+    writeReg(ES8388_MASTERMODE, 0x00);
+
+    /* power up DAC and enable LOUT1+2 / ROUT1+2, ADC sample rate = DAC sample rate */
+    writeReg(ES8388_DACPOWER, 0x3e);
+    writeReg(ES8388_CONTROL1, 0x12);
+
+    /* DAC I2S setup: 16 bit word length, I2S format; MCLK / Fs = 256*/
+    writeReg(ES8388_DACCONTROL1, 0x18);
+    writeReg(ES8388_DACCONTROL2, 0x02);
+
+    /* DAC to output route mixer configuration: ADC MIX TO OUTPUT */
+    writeReg(ES8388_DACCONTROL16, 0x1B);
+    writeReg(ES8388_DACCONTROL17, 0x90);
+    writeReg(ES8388_DACCONTROL20, 0x90);
+
+    /* DAC and ADC use same LRCK, enable MCLK input; output resistance setup */
+    writeReg(ES8388_DACCONTROL21, 0x80);
+    writeReg(ES8388_DACCONTROL23, 0x00);
+
+    /* DAC volume control: 0dB (maximum, unattented)  */
+    writeReg(ES8388_DACCONTROL5, 0x00);
+    writeReg(ES8388_DACCONTROL4, 0x00);
+
+    /* power down ADC while configuring; volume: +9dB for both channels */
+    writeReg(ES8388_ADCPOWER, 0xff);
+    writeReg(ES8388_ADCCONTROL1, 0x88); // +24db
+
+    /* select LINPUT2 / RINPUT2 as ADC input; stereo; 16 bit word length, format right-justified, MCLK / Fs = 256 */
+    writeReg(ES8388_ADCCONTROL2, 0xf0); // 50
+    writeReg(ES8388_ADCCONTROL3, 0x80); // 00
+    writeReg(ES8388_ADCCONTROL4, 0x0e);
+    writeReg(ES8388_ADCCONTROL5, 0x02);
+
+    /* set ADC volume */
+    writeReg(ES8388_ADCCONTROL8, 0x20);
+    writeReg(ES8388_ADCCONTROL9, 0x20);
+
+    /* set LOUT1 / ROUT1 volume: 0dB (unattenuated) */
+    writeReg(ES8388_DACCONTROL24, 0x1e);
+    writeReg(ES8388_DACCONTROL25, 0x1e);
+
+    /* set LOUT2 / ROUT2 volume: 0dB (unattenuated) */
+    writeReg(ES8388_DACCONTROL26, 0x1e);
+    writeReg(ES8388_DACCONTROL27, 0x1e);
+
+    /* power up and enable DAC; power up ADC (no MIC bias) */
+    writeReg(ES8388_DACPOWER, 0x3c);
+    writeReg(ES8388_DACCONTROL3, 0x00);
+    writeReg(ES8388_ADCPOWER, 0x00);
+
+    startI2sFeed();
+}
+
+void ES8388AudioSink::writeReg(uint8_t reg_add, uint8_t data)
+{
+
+    int res = 0;
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    res |= i2c_master_start(cmd);
+    res |= i2c_master_write_byte(cmd, ES8388_ADDR, ACK_CHECK_EN);
+    res |= i2c_master_write_byte(cmd, reg_add, ACK_CHECK_EN);
+    res |= i2c_master_write_byte(cmd, data, ACK_CHECK_EN);
+    res |= i2c_master_stop(cmd);
+    res |= i2c_master_cmd_begin(0, cmd, 1000 / portTICK_RATE_MS);
+    i2c_cmd_link_delete(cmd);
+
+    if (res != ESP_OK) {
+        ESP_LOGE("RR", "Unable to write to ES8388: %d", res);
+    }else{
+        ESP_LOGE("RR", "register successfull written.");
+    }
+}
+
+ES8388AudioSink::~ES8388AudioSink()
+{
+}

--- a/targets/esp32/main/sinks/ES8388AudioSink.h
+++ b/targets/esp32/main/sinks/ES8388AudioSink.h
@@ -1,0 +1,105 @@
+#ifndef ES8388AUDIOSINK_H
+#define ES8388AUDIOSINK_H
+
+#include "driver/i2s.h"
+#include <driver/i2c.h>
+#include <vector>
+#include <iostream>
+#include "BufferedAudioSink.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include "esp_err.h"
+#include "esp_log.h"
+
+
+#define ES8388_ADDR 0x20
+
+#define ACK_CHECK_EN   		0x1 
+
+/* ES8388 register */
+#define ES8388_CONTROL1 0x00
+#define ES8388_CONTROL2 0x01
+#define ES8388_CHIPPOWER 0x02
+#define ES8388_ADCPOWER 0x03
+#define ES8388_DACPOWER 0x04
+#define ES8388_CHIPLOPOW1 0x05
+#define ES8388_CHIPLOPOW2 0x06
+#define ES8388_ANAVOLMANAG 0x07
+#define ES8388_MASTERMODE 0x08
+
+/* ADC */
+#define ES8388_ADCCONTROL1 0x09
+#define ES8388_ADCCONTROL2 0x0a
+#define ES8388_ADCCONTROL3 0x0b
+#define ES8388_ADCCONTROL4 0x0c
+#define ES8388_ADCCONTROL5 0x0d
+#define ES8388_ADCCONTROL6 0x0e
+#define ES8388_ADCCONTROL7 0x0f
+#define ES8388_ADCCONTROL8 0x10
+#define ES8388_ADCCONTROL9 0x11
+#define ES8388_ADCCONTROL10 0x12
+#define ES8388_ADCCONTROL11 0x13
+#define ES8388_ADCCONTROL12 0x14
+#define ES8388_ADCCONTROL13 0x15
+#define ES8388_ADCCONTROL14 0x16
+
+/* DAC */
+#define ES8388_DACCONTROL1 0x17
+#define ES8388_DACCONTROL2 0x18
+#define ES8388_DACCONTROL3 0x19
+#define ES8388_DACCONTROL4 0x1a
+#define ES8388_DACCONTROL5 0x1b
+#define ES8388_DACCONTROL6 0x1c
+#define ES8388_DACCONTROL7 0x1d
+#define ES8388_DACCONTROL8 0x1e
+#define ES8388_DACCONTROL9 0x1f
+#define ES8388_DACCONTROL10 0x20
+#define ES8388_DACCONTROL11 0x21
+#define ES8388_DACCONTROL12 0x22
+#define ES8388_DACCONTROL13 0x23
+#define ES8388_DACCONTROL14 0x24
+#define ES8388_DACCONTROL15 0x25
+#define ES8388_DACCONTROL16 0x26
+#define ES8388_DACCONTROL17 0x27
+#define ES8388_DACCONTROL18 0x28
+#define ES8388_DACCONTROL19 0x29
+#define ES8388_DACCONTROL20 0x2a
+#define ES8388_DACCONTROL21 0x2b
+#define ES8388_DACCONTROL22 0x2c
+#define ES8388_DACCONTROL23 0x2d
+#define ES8388_DACCONTROL24 0x2e
+#define ES8388_DACCONTROL25 0x2f
+#define ES8388_DACCONTROL26 0x30
+#define ES8388_DACCONTROL27 0x31
+#define ES8388_DACCONTROL28 0x32
+#define ES8388_DACCONTROL29 0x33
+#define ES8388_DACCONTROL30 0x34
+
+class ES8388AudioSink : public BufferedAudioSink
+{
+public:
+    ES8388AudioSink();
+    ~ES8388AudioSink();
+    
+    bool begin(int sda = -1, int scl = -1, uint32_t frequency = 400000U);
+
+    enum ES8388_OUT
+    {
+        ES_MAIN, // this is the DAC output volume (both outputs)
+        ES_OUT1, // this is the additional gain for OUT1
+        ES_OUT2  // this is the additional gain for OUT2
+    };
+
+    void mute(const ES8388_OUT out, const bool muted);
+    void volume(const ES8388_OUT out, const uint8_t vol);
+
+    void writeReg(uint8_t reg_add, uint8_t data);
+private:
+    i2c_config_t i2c_config;
+    i2c_port_t i2c_port = 0;
+};
+
+#endif


### PR DESCRIPTION
this pull request should add support for the (newer) ESP32-A1S AudioKIT Boards from AI Thinker, as these has the ES8388 chip as DAC instead AC101.

with little adjustments (GPIOs) it should work with ESP32 Lyrat Boards (with ES8388 chips) - but this is untestet.

You need to adjust targets/esp32/main/main.cpp in line 38 to match the new chip.

===
Sorry for any bad coding style or bad mistakes in this pull request. i never before coded in c/cpp.
This PR is heavilly bases on copy/paste/test/debug