### PR TITLE
Fix sinks on ESP32 and add instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ $ make
 ```
 See running the CLI for information on how to run cspot on a desktop computer.
 
+### Building for ESP32
+
+The ESP32 target is built using the esp-idf toolchain
+
+```shell
+# navigate to the targets/esp32 directory
+$ cd targets/esp32
+```
+
+Configure the `main/main.cpp` to match your DAC
+```c++
+// Config sink
+#define AC101 // INTERNAL, AC101, ES8018, PCM5102
+#define QUALITY     320      // 320, 160, 96
+#define DEVICE_NAME "CSpot-ESP32"
+```
+
+Build and upload the firmware
+```shell
+# compile
+$ idf.py build
+
+# upload
+$ idf.py flash
+```
+The ESP32 will restart and begin running cspot. You can monitor it using a serial console.
+
 ## Running
 
 ## The CLI version

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -74,7 +74,19 @@ static void cspotTask(void *pvParameters)
 
     mdns_init();
     mdns_hostname_set("cspot");
+
+#ifdef INTERNAL
+    auto audioSink = std::make_shared<InternalAudioSink>();
+#endif
+#ifdef AC101
     auto audioSink = std::make_shared<AC101AudioSink>();
+#endif
+#ifdef ES8018
+    auto audioSink = std::make_shared<ES8018AudioSink>();
+#endif
+#ifdef PCM5102
+    auto audioSink = std::make_shared<PCM5102AudioSink>();
+#endif
 
     // Config file
     file = std::make_shared<ESPFile>();


### PR DESCRIPTION
I was playing around building the project for the esp-wrover. I'm using a MAX98357 DAC which is functionality similar to the PCM5102 that is already supported but has a built-in mono amp. I had to tweak the code after the sinks where moved. Otherwise no problems at all and the music plays without issue.

I also realised that the instructions were somewhat lacking for ESP32 so threw some together - happy to remove them from the PR if they're no good.