### PR TITLE
Misc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cspot/bell"]
 	path = cspot/bell
 	url = https://github.com/philippe44/bell
-	branch = Windows+fixes
+	branch = misc

--- a/cspot/include/ApResolve.h
+++ b/cspot/include/ApResolve.h
@@ -4,7 +4,11 @@
 #include <string>
 
 #include "HTTPClient.h"
+#ifdef BELL_ONLY_CJSON
+#include "cJSON.h"
+#else
 #include "nlohmann/json.hpp"
+#endif
 
 namespace cspot {
 class ApResolve {

--- a/cspot/include/CDNTrackStream.h
+++ b/cspot/include/CDNTrackStream.h
@@ -10,7 +10,6 @@
 #include "CSpotContext.h"
 #include "AccessKeyFetcher.h"
 
-
 namespace cspot {
 
 class CDNTrackStream {

--- a/cspot/include/CSpotContext.h
+++ b/cspot/include/CSpotContext.h
@@ -29,12 +29,10 @@ struct Context {
     ctx->timeProvider = std::make_shared<TimeProvider>();
 
     ctx->session = std::make_shared<MercurySession>(ctx->timeProvider);
-    ctx->config = {
-        .deviceId = blob->getDeviceId(),
-        .deviceName = blob->getDeviceName(),
-        .volume = 0,
-        .username = blob->getUserName()
-    };
+    ctx->config.deviceId = blob->getDeviceId();
+    ctx->config.deviceName = blob->getDeviceName();
+    ctx->config.volume = 0;
+    ctx->config.username = blob->getUserName();
 
     return ctx;
   }

--- a/cspot/include/LoginBlob.h
+++ b/cspot/include/LoginBlob.h
@@ -3,7 +3,9 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#ifndef BELL_ONLY_CJSON
 #include <nlohmann/json.hpp>
+#endif
 #include <vector>
 
 #include "ConstantParameters.h"

--- a/cspot/include/PlainConnection.h
+++ b/cspot/include/PlainConnection.h
@@ -8,6 +8,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include "sys/socket.h"
+#include <netinet/in.h>
 #endif
 #include <cstdint>
 #include <functional>

--- a/cspot/include/Utils.h
+++ b/cspot/include/Utils.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include "sys/socket.h"
 #include <netdb.h>
+#include <netinet/in.h>
 #endif
 #include <cstdint>
 #include <cstring>

--- a/cspot/src/ApResolve.cpp
+++ b/cspot/src/ApResolve.cpp
@@ -18,6 +18,13 @@ std::string ApResolve::fetchFirstApAddress()
     std::string_view responseStr = request->body();
 
     // parse json with nlohmann
+#if BELL_ONLY_CJSON
+   cJSON* json = cJSON_Parse(responseStr.data());
+   auto ap_string = std::string(cJSON_GetArrayItem(cJSON_GetObjectItem(json, "ap_list"), 0)->valuestring);
+   cJSON_Delete(json);
+   return ap_string;
+#else    
     auto json = nlohmann::json::parse(responseStr);
     return json["ap_list"][0];
+#endif    
 }

--- a/cspot/src/CDNTrackStream.cpp
+++ b/cspot/src/CDNTrackStream.cpp
@@ -38,8 +38,14 @@ void CDNTrackStream::fetchFile(const std::vector<uint8_t>& trackId,
 
     std::string_view result = req->body();
 
+#ifdef BELL_ONLY_CJSON
+    cJSON* jsonResult = cJSON_Parse(result.data());
+    std::string cdnUrl = cJSON_GetArrayItem(cJSON_GetObjectItem(jsonResult, "cdnurl"), 0)->valuestring;
+    cJSON_Delete(jsonResult);
+#else
     auto jsonResult = nlohmann::json::parse(result);
     std::string cdnUrl = jsonResult["cdnurl"][0];
+#endif
     if (this->status != Status::FAILED) {
 
       this->cdnUrl = cdnUrl;

--- a/cspot/src/MercurySession.cpp
+++ b/cspot/src/MercurySession.cpp
@@ -110,7 +110,7 @@ std::string MercurySession::getCountryCode() {
 void MercurySession::handlePacket() {
   Packet packet = {};
 
-  this->packetQueue.wtpop(packet, 10);
+  this->packetQueue.wtpop(packet, 200);
 
   if (executeEstabilishedCallback && this->connectionReadyCallback != nullptr) {
     executeEstabilishedCallback = false;
@@ -167,7 +167,8 @@ void MercurySession::handlePacket() {
 }
 
 void MercurySession::failAllPending() {
-  Response response = {.fail = true};
+  Response response = { };
+  response.fail = true;
 
   // Fail all callbacks
   for (auto& it : this->callbacks) {

--- a/cspot/src/MercurySession.cpp
+++ b/cspot/src/MercurySession.cpp
@@ -120,9 +120,9 @@ void MercurySession::handlePacket() {
   switch (static_cast<RequestType>(packet.command)) {
     case RequestType::COUNTRY_CODE_RESPONSE: {
       this->countryCode = std::string();
-      this->countryCode.reserve(2);
+      this->countryCode.resize(2);
       memcpy(this->countryCode.data(), packet.data.data(), 2);
-      CSPOT_LOG(debug, "Received country code");
+      CSPOT_LOG(debug, "Received country code %s", this->countryCode.c_str());
       break;
     }
     case RequestType::AUDIO_KEY_FAILURE_RESPONSE:

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -150,7 +150,7 @@ void TrackPlayer::runTask() {
                 dataCallback(pcmBuffer.data() + (ret - toWrite), toWrite,
                              this->currentTrackStream->trackInfo.trackId, this->sequence);
             if (written == 0) {
-              BELL_SLEEP_MS(10);
+              BELL_SLEEP_MS(50);
             }
             toWrite -= written;
           }

--- a/cspot/src/TrackProvider.cpp
+++ b/cspot/src/TrackProvider.cpp
@@ -77,12 +77,11 @@ void TrackProvider::onMetadataResponse(MercurySession::Response& res) {
 
   std::vector<uint8_t> trackId;
   std::vector<uint8_t> fileId;
-  AudioFormat format = AudioFormat_OGG_VORBIS_160;
-
+  
   if (altIndex < 0) {
     trackId = pbArrayToVector(trackInfo.gid);
     for (int x = 0; x < trackInfo.file_count; x++) {
-      if (trackInfo.file[x].format == format) {
+      if (trackInfo.file[x].format == ctx->config.audioFormat) {
         fileId = pbArrayToVector(trackInfo.file[x].file_id);
         break;  // If file found stop searching
       }
@@ -90,7 +89,7 @@ void TrackProvider::onMetadataResponse(MercurySession::Response& res) {
   } else {
     trackId = pbArrayToVector(trackInfo.alternative[altIndex].gid);
     for (int x = 0; x < trackInfo.alternative[altIndex].file_count; x++) {
-      if (trackInfo.alternative[altIndex].file[x].format == format) {
+      if (trackInfo.alternative[altIndex].file[x].format == ctx->config.audioFormat) {
         fileId =
             pbArrayToVector(trackInfo.alternative[altIndex].file[x].file_id);
         break;  // If file found stop searching


### PR DESCRIPTION
Make it compile and run under SunOS and FreeBSD.

[edit]: I've also added a few fixes for esp32
- adding BELL_ONLY_CJSON flag see bell for more details
- esp32: struct named initializer is not fully compliant in GCC 8.x
- esp32: mercury session packet timeout is way to small for esp32, 200 ms is enough so that we gain control in main loop
- esp32: TrackPlayer was hammering a bit the esp32 with a sleep timer of 10ms when it could not write decoded Vorbis frame into buffers, where 50ms is probably more than enough
- fix country code in context's config (std::resize instead of std::reserve)
- honor bitrate request in TrackProvider

With all these changes, cspot + bell are ~170kB less on esp32 and nicely fits now