### PR TITLE
Fix "plop" on seeking and bring back esp32/Windows

### DIFF
--- a/cspot/src/AccessKeyFetcher.cpp
+++ b/cspot/src/AccessKeyFetcher.cpp
@@ -13,8 +13,12 @@
 #include "Packet.h"               // for cspot
 #include "TimeProvider.h"         // for TimeProvider
 #include "Utils.h"                // for string_format
+#ifdef BELL_ONLY_CJSON
+#include "cJSON.h"
+#else
 #include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json
 #include "nlohmann/json_fwd.hpp"  // for json
+#endif
 
 using namespace cspot;
 

--- a/cspot/src/ApResolve.cpp
+++ b/cspot/src/ApResolve.cpp
@@ -7,8 +7,12 @@
 #include <vector>                 // for vector
 
 #include "HTTPClient.h"           // for HTTPClient, HTTPClient::Response
+#ifdef BELL_ONLY_CJSON
+#include "cJSON.h"
+#else
 #include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json
 #include "nlohmann/json_fwd.hpp"  // for json
+#endif
 
 using namespace cspot;
 
@@ -28,7 +32,7 @@ std::string ApResolve::fetchFirstApAddress()
     std::string_view responseStr = request->body();
 
     // parse json with nlohmann
-#if BELL_ONLY_CJSON
+#ifdef BELL_ONLY_CJSON
    cJSON* json = cJSON_Parse(responseStr.data());
    auto ap_string = std::string(cJSON_GetArrayItem(cJSON_GetObjectItem(json, "ap_list"), 0)->valuestring);
    cJSON_Delete(json);

--- a/cspot/src/CDNTrackStream.cpp
+++ b/cspot/src/CDNTrackStream.cpp
@@ -14,8 +14,12 @@
 #include "SocketStream.h"         // for SocketStream
 #include "Utils.h"                // for bigNumAdd, bytesToHexString, string...
 #include "WrappedSemaphore.h"     // for WrappedSemaphore
+#ifdef BELL_ONLY_CJSON
+#include "cJSON.h"
+#else
 #include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json
 #include "nlohmann/json_fwd.hpp"  // for json
+#endif
 
 using namespace cspot;
 

--- a/cspot/src/LoginBlob.cpp
+++ b/cspot/src/LoginBlob.cpp
@@ -6,12 +6,13 @@
 #include "BellLogger.h"                      // for AbstractLogger
 #include "ConstantParameters.h"              // for brandName, cspot, protoc...
 #include "Logger.h"                          // for CSPOT_LOG
-#include "nlohmann/detail/json_pointer.hpp"  // for json_pointer<>::string_t
-#include "nlohmann/json.hpp"                 // for basic_json<>::object_t
-#include "nlohmann/json_fwd.hpp"             // for json
 #include "protobuf/authentication.pb.h"      // for AuthenticationType_AUTHE...
 #ifdef BELL_ONLY_CJSON
 #include "cJSON.h"
+#else
+#include "nlohmann/detail/json_pointer.hpp"  // for json_pointer<>::string_t
+#include "nlohmann/json.hpp"                 // for basic_json<>::object_t
+#include "nlohmann/json_fwd.hpp"             // for json
 #endif
 
 using namespace cspot;

--- a/cspot/src/MercurySession.cpp
+++ b/cspot/src/MercurySession.cpp
@@ -7,6 +7,10 @@
 #include <type_traits>  // for remove_extent_t, __underlying_type_impl<>:...
 #include <utility>      // for pair
 
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
+
 #include "BellLogger.h"         // for AbstractLogger
 #include "BellTask.h"           // for Task
 #include "BellUtils.h"          // for BELL_SLEEP_MS
@@ -16,7 +20,6 @@
 #include "ShannonConnection.h"  // for ShannonConnection
 #include "TimeProvider.h"       // for TimeProvider
 #include "Utils.h"              // for extract, pack, hton64
-#include "i386/endian.h"        // for htons, ntohs, htonl, ntohl
 
 using namespace cspot;
 

--- a/cspot/src/PlainConnection.cpp
+++ b/cspot/src/PlainConnection.cpp
@@ -1,22 +1,24 @@
 #include "PlainConnection.h"
 
+#ifndef _WIN32
 #include <netdb.h>        // for addrinfo, freeaddrinfo, getaddrinfo
 #include <netinet/in.h>   // for IPPROTO_IP, IPPROTO_TCP
 #include <sys/errno.h>    // for EAGAIN, EINTR, ETIMEDOUT, errno
 #include <sys/socket.h>   // for setsockopt, connect, recv, send, shutdown
 #include <sys/time.h>     // for timeval
+#endif
 #include <cstring>        // for memset
 #include <stdexcept>      // for runtime_error
 #ifdef _WIN32
 #include <ws2tcpip.h>
 #else
 #include <netinet/tcp.h>  // for TCP_NODELAY
+#include <arpa/inet.h>
 #endif
 #include "BellLogger.h"   // for AbstractLogger
 #include "Logger.h"       // for CSPOT_LOG
 #include "Packet.h"       // for cspot
 #include "Utils.h"        // for extract, pack
-#include "i386/endian.h"  // for htonl, ntohl
 
 using namespace cspot;
 

--- a/cspot/src/ShannonConnection.cpp
+++ b/cspot/src/ShannonConnection.cpp
@@ -2,13 +2,16 @@
 
 #include <type_traits>  // for remove_extent_t
 
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
+
 #include "BellLogger.h"       // for AbstractLogger
 #include "Logger.h"           // for CSPOT_LOG
 #include "Packet.h"           // for Packet, cspot
 #include "PlainConnection.h"  // for PlainConnection
 #include "Shannon.h"          // for Shannon
 #include "Utils.h"            // for pack, extract
-#include "i386/endian.h"      // for htonl, htons, ntohs
 
 using namespace cspot;
 

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -163,9 +163,9 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
        * when last track has been reached, we has to restart as we can't tell the difference */
       if ((!isNextTrackPreloaded && this->playbackState.getNextTrackRef()) || isRequestedFromLoad) {
           CSPOT_LOG(debug, "Seek command while streaming current");
-          sendEvent(EventType::SEEK, (int)playbackState.remoteFrame.position);
           playbackState.updatePositionMs(playbackState.remoteFrame.position);
           trackPlayer->seekMs(playbackState.remoteFrame.position);
+          sendEvent(EventType::SEEK, (int)playbackState.remoteFrame.position);		  
       } else {
           CSPOT_LOG(debug, "Seek command while streaming next or before started");
           isRequestedFromLoad = true;

--- a/cspot/src/TimeProvider.cpp
+++ b/cspot/src/TimeProvider.cpp
@@ -1,9 +1,12 @@
 #include "TimeProvider.h"
 
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
+
 #include "BellLogger.h"   // for AbstractLogger
 #include "Logger.h"       // for CSPOT_LOG
 #include "Utils.h"        // for extract, getCurrentTimestamp
-#include "i386/endian.h"  // for ntohl
 
 using namespace cspot;
 

--- a/cspot/src/TrackProvider.cpp
+++ b/cspot/src/TrackProvider.cpp
@@ -31,11 +31,12 @@ TrackProvider::TrackProvider(std::shared_ptr<cspot::Context> ctx) {
       std::make_unique<cspot::CDNTrackStream>(this->accessKeyFetcher);
 
   this->trackInfo = {};
+  this->episodeInfo = {};
 }
 
 TrackProvider::~TrackProvider() {
   pb_release(Track_fields, &trackInfo);
-  pb_release(Episode_fields, &trackInfo);
+  pb_release(Episode_fields, &episodeInfo);
 }
 
 std::shared_ptr<cspot::CDNTrackStream> TrackProvider::loadFromTrackRef(

--- a/cspot/src/Utils.cpp
+++ b/cspot/src/Utils.cpp
@@ -6,8 +6,10 @@
 #include <sstream>      // for stringstream
 #include <string>       // for string
 #include <type_traits>  // for enable_if<>::type
-
-#include "i386/endian.h"  // for htonl
+#include <chrono>
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
 
 unsigned long long getCurrentTimestamp() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
Hopefully this deals with iwyu mess as well, although I'm not sure what shoudl be set on macOS wrt htonl/htons and friends. It also fixes a bug where on TracProvider destructor not only episodeInfo was not used to pb_release episodeField but episodeInfo was not zero-initialized