### PR TITLE
Bring back username/password to make it work under CDN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cspot/bell"]
 	path = cspot/bell
 	url = https://github.com/philippe44/bell
-	branch = misc
+	branch = develop

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ After building the app, the only thing you need to do is to run it through CLI.
 $ ./cspotcli
 
 ```
+If you run it with no parameter, it will use ZeroConf to advertise itself. This means that until at least one **local** Spotify Connect application has discovered and connected it, it will not be registered to Spotify servers. As a consequence, Spotify's WebAPI will not be able to see it. If you want the player to be registered at start-up, you need to either use username/password all the time or at least once to create a credentials file and then re-use that file. Run it with -u/-p/-c once and then run it with -c only. See command's line help.
 
 Now open a real Spotify app and you should see a cspot device on your local network. Use it to play audio.
 

--- a/cspot/include/CSpotContext.h
+++ b/cspot/include/CSpotContext.h
@@ -6,7 +6,16 @@
 #include "LoginBlob.h"
 #include "MercurySession.h"
 #include "TimeProvider.h"
+#include "Crypto.h"  
 #include "protobuf/metadata.pb.h"
+#include "protobuf/authentication.pb.h"      // for AuthenticationType_AUTHE...
+#ifdef BELL_ONLY_CJSON
+#include "cJSON.h"
+#else
+#include "nlohmann/detail/json_pointer.hpp"  // for json_pointer<>::string_t
+#include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json
+#include "nlohmann/json_fwd.hpp"  // for json
+#endif
 
 namespace cspot {
 struct Context {
@@ -26,6 +35,28 @@ struct Context {
 
   std::shared_ptr<TimeProvider> timeProvider;
   std::shared_ptr<cspot::MercurySession> session;
+  std::string getCredentialsJson() {
+#ifdef BELL_ONLY_CJSON
+      cJSON* json_obj = cJSON_CreateObject();
+      cJSON_AddStringToObject(json_obj, "authData", Crypto::base64Encode(config.authData).c_str());
+      cJSON_AddNumberToObject(json_obj, "authType", AuthenticationType_AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS);
+      cJSON_AddStringToObject(json_obj, "username", config.username.c_str());
+
+      char* str = cJSON_PrintUnformatted(json_obj);
+      cJSON_Delete(json_obj);
+      std::string json_objStr(str);
+      free(str);
+
+      return json_objStr;
+#else
+      nlohmann::json obj;
+      obj["authData"] = Crypto::base64Encode(config.authData);
+      obj["authType"] = AuthenticationType_AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS;
+      obj["username"] = config.username;
+
+      return obj.dump();
+#endif
+  }
 
   static std::shared_ptr<Context> createFromBlob(
       std::shared_ptr<LoginBlob> blob) {

--- a/cspot/protobuf/authentication.options
+++ b/cspot/protobuf/authentication.options
@@ -3,3 +3,8 @@ LoginCredentials.auth_data max_size:512, fixed_length:false
 SystemInfo.system_information_string max_size:16, fixed_length:false
 SystemInfo.device_id max_size:50, fixed_length:false
 ClientResponseEncrypted.version_string max_size:32, fixed_length:false
+APWelcome.canonical_username max_size:30, fixed_length:false
+APWelcome.reusable_auth_credentials max_size:512, fixed_length:false
+APWelcome.lfs_secret max_size:128, fixed_length:false
+AccountInfoFacebook.access_token max_size:128, fixed_length:false
+AccountInfoFacebook.machine_id max_size:50, fixed_length:false

--- a/cspot/protobuf/authentication.proto
+++ b/cspot/protobuf/authentication.proto
@@ -37,6 +37,11 @@ enum Os {
     OS_BCO = 0x16;
 }
 
+enum AccountType {
+    Spotify = 0x0;
+    Facebook = 0x1;
+}
+
 enum AuthenticationType {
     AUTHENTICATION_USER_PASS = 0x0;
     AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS = 0x1;
@@ -62,4 +67,28 @@ message ClientResponseEncrypted {
     required LoginCredentials login_credentials = 0xa; 
     required SystemInfo system_info = 0x32; 
     optional string version_string = 0x46; 
+}
+
+message APWelcome {
+    required string canonical_username = 0xa;
+    required AccountType account_type_logged_in = 0x14;
+    required AccountType credentials_type_logged_in = 0x19;
+    required AuthenticationType reusable_auth_credentials_type = 0x1e;
+    required bytes reusable_auth_credentials = 0x28;
+    optional bytes lfs_secret = 0x32; 
+    optional AccountInfo account_info = 0x3c;
+    optional AccountInfoFacebook fb = 0x46;
+}
+
+message AccountInfo {
+    optional AccountInfoSpotify spotify = 0x1;
+    optional AccountInfoFacebook facebook = 0x2;
+}
+
+message AccountInfoSpotify {
+}
+
+message AccountInfoFacebook {
+    optional string access_token = 0x1;
+    optional string machine_id = 0x2;
 }

--- a/cspot/src/CDNAudioFile.cpp
+++ b/cspot/src/CDNAudioFile.cpp
@@ -16,7 +16,7 @@
 #include "Utils.h"                // for bigNumAdd, bytesToHexString, string...
 #include "WrappedSemaphore.h"     // for WrappedSemaphore
 #ifdef BELL_ONLY_CJSON
-#include "cJSON.h "
+#include "cJSON.h"
 #else
 #include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json
 #include "nlohmann/json_fwd.hpp"  // for json

--- a/cspot/src/LoginBlob.cpp
+++ b/cspot/src/LoginBlob.cpp
@@ -8,7 +8,7 @@
 #include "Logger.h"                          // for CSPOT_LOG
 #include "protobuf/authentication.pb.h"      // for AuthenticationType_AUTHE...
 #ifdef BELL_ONLY_CJSON
-#include "cJSON.h "
+#include "cJSON.h"
 #else
 #include "nlohmann/detail/json_pointer.hpp"  // for json_pointer<>::string_t
 #include "nlohmann/json.hpp"      // for basic_json<>::object_t, basic_json

--- a/targets/cli/CommandLineArguments.cpp
+++ b/targets/cli/CommandLineArguments.cpp
@@ -6,16 +6,16 @@
 #include "protobuf/metadata.pb.h"  // for AudioFormat_OGG_VORBIS_160, AudioF...
 
 CommandLineArguments::CommandLineArguments(std::string u, std::string p,
-                                           bool shouldShowHelp)
-    : username(u), password(p), shouldShowHelp(shouldShowHelp) {}
+                                           std::string c, bool shouldShowHelp)
+    : username(u), password(p), credentials(c), shouldShowHelp(shouldShowHelp) {}
 
 std::shared_ptr<CommandLineArguments> CommandLineArguments::parse(int argc,
                                                                   char** argv) {
 
   if (argc == 1) {
-    return std::make_shared<CommandLineArguments>("", "", false);
+    return std::make_shared<CommandLineArguments>("", "", "", false);
   }
-  auto result = std::make_shared<CommandLineArguments>("", "", false);
+  auto result = std::make_shared<CommandLineArguments>("", "", "", false);
   for (int i = 1; i < argc; i++) {
     auto stringVal = std::string(argv[i]);
 
@@ -36,6 +36,11 @@ std::shared_ptr<CommandLineArguments> CommandLineArguments::parse(int argc,
         throw std::invalid_argument("expected path after the password flag");
       }
       result->password = std::string(argv[++i]);
+    } else if (stringVal == "-c" || stringVal == "--credentials") {
+        if (i >= argc - 1) {
+            throw std::invalid_argument("expected path after the credentials flag");
+        }
+        result->credentials = std::string(argv[++i]);
     } else if (stringVal == "-b" || stringVal == "--bitrate") {
       if (i >= argc - 1) {
         throw std::invalid_argument("expected path after the bitrate flag");

--- a/targets/cli/CommandLineArguments.h
+++ b/targets/cli/CommandLineArguments.h
@@ -19,6 +19,10 @@ class CommandLineArguments {
     */
   std::string password;
   /**
+     * A file to store/read reusable credentials from
+    */
+  std::string credentials;
+  /**
      * Bitrate setting.
     */
   bool setBitrate = false;
@@ -31,8 +35,8 @@ class CommandLineArguments {
      * This is a constructor which initializez all the fields of CommandLineArguments
      * @param shouldShowHelp determines whether the help text should be printed.
      */
-  CommandLineArguments(std::string username, std::string password,
-                       bool shouldShowHelp);
+  CommandLineArguments(std::string username, std::string password, 
+                       std::string credentials, bool shouldShowHelp);
 
   /**
      * Parses command line arguments, as they are passed to main().

--- a/targets/cli/main.cpp
+++ b/targets/cli/main.cpp
@@ -150,6 +150,7 @@ int main(int argc, char** argv) {
       std::cout << "-p, --password            your spotify password, note that "
                    "if you use facebook login you can set a password in your "
                    "account settings\n";
+      std::cout << "-c, --credentials         json file to store/load reusable credentials\n";
       std::cout << "-b, --bitrate             bitrate (320, 160, 96)\n";
       std::cout << "\n";
       std::cout << "ddd 2022\n";


### PR DESCRIPTION
This PR is mainly to enable username/password credential now that we use CDN and need a token to access it. 

The idea is that when using username/password, the AccessKey request would fail as we still use such u/p credentials where in fact we should use stored reusable credentials (the one obtained after authentication using u/p). This PR does not overwrite the authData in blob or ctx->config but instead return reusable credendials obtained after Session::authenticate and let the application replace ctx->authData (which main be the password in case username/password was used) by these. Now an AccessKey can be obtained. 

I've also modified the example so that the credentials can be stored in a json file that can be used later, instead or requiring user/password again. It's less dangerous than forcing people to use password all the time, they just have to secure the json file.

That also answers the issue https://github.com/feelfreelinux/cspot/issues/153

NB: also fix a tiny typo in header files and  the .gitmodules wrongly points to my Bell repository fork, should be ignored