### PR TITLE
fix deadlock in TrackPlayer during spirc::disconnect

### DIFF
--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -111,7 +111,7 @@ void SpircHandler::updatePositionMs(uint32_t position) {
 
 void SpircHandler::disconnect() {
   this->trackQueue->stopTask();
-  this->trackPlayer->resetState();
+  this->trackPlayer->stop();
   this->ctx->session->disconnect();
 }
 

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -70,6 +70,7 @@ TrackPlayer::TrackPlayer(std::shared_ptr<cspot::Context> ctx,
 
 TrackPlayer::~TrackPlayer() {
   isRunning = false;
+  resetState();
   std::scoped_lock lock(runningMutex);
 }
 


### PR DESCRIPTION
SpircHandler:: disconnect() does a TrackPlayer->resetState() but that's not enough because TrackPlayer will abort the current track and if there is a next one, it will grab it immediately and try to stream it.

It is expected that after disconnect(), SpircHandler instance will be deleted and so will it's TrackPlayer object. In its destructor, TrackPlayer sets isRunning to false but that will not exit the task if it is still trying to stream and we have a deadlock => SpircHandler can't be destroyed because TrackPlayer can't be. 

The solution could be to just add a resetState() in TrackPlayer's destructor so that at least it exits the busy streaming loop and because isRunning is false it will fully exit as well, returning to SpircHandler destructor. Still, I think this is better to call TrackPlayer::stop() in SpircHandler::disconnect() so that the trackPlayer object is *actuallyù deactivated because it prevents it to try to grab another track. And it should not dot that because, AFAIU, there is no future for a disconnected spircHandler, except being destroyed.

By the same token, adding resetState() in TrackPlayer's destructor is then not mandatory if SpircHandler::disconnect calls TrackPlayer::stop() instead of resetState() because upon TrackPlayer's destruction, SpircHJandler has guaranteed it is not any more in the stream busy loop... well I'll let you judge of that, I prefer to have added that as a safety precaution in case I forgot something. 

