### PR TITLE
fix podcast won't play

### DIFF
--- a/cspot/include/SpircHandler.h
+++ b/cspot/include/SpircHandler.h
@@ -48,9 +48,9 @@ class SpircHandler {
 
   void setPause(bool pause);
 
-  void previousSong();
+  bool previousSong();
 
-  void nextSong();
+  bool nextSong();
 
   void notifyAudioReachedPlayback();
   void updatePositionMs(uint32_t position);
@@ -74,7 +74,7 @@ class SpircHandler {
   void sendEvent(EventType type);
   void sendEvent(EventType type, EventData data);
 
-  void skipSong(TrackQueue::SkipDirection dir);
+  bool skipSong(TrackQueue::SkipDirection dir);
   void handleFrame(std::vector<uint8_t>& data);
   void notify();
 };

--- a/cspot/include/SpircHandler.h
+++ b/cspot/include/SpircHandler.h
@@ -53,6 +53,7 @@ class SpircHandler {
   bool nextSong();
 
   void notifyAudioReachedPlayback();
+  void notifyAudioEnded();
   void updatePositionMs(uint32_t position);
   void setRemoteVolume(int volume);
   void loadTrackFromURI(const std::string& uri);

--- a/cspot/include/TrackPlayer.h
+++ b/cspot/include/TrackPlayer.h
@@ -32,7 +32,7 @@ struct TrackReference;
 class TrackPlayer : bell::Task {
  public:
   // Callback types
-  typedef std::function<void(std::shared_ptr<QueuedTrack>)> TrackLoadedCallback;
+  typedef std::function<void(std::shared_ptr<QueuedTrack>, bool)> TrackLoadedCallback;
   typedef std::function<size_t(uint8_t*, size_t, std::string_view)>
       DataCallback;
   typedef std::function<void()> EOFCallback;
@@ -49,7 +49,7 @@ class TrackPlayer : bell::Task {
 
   // CDNTrackStream::TrackInfo getCurrentTrackInfo();
   void seekMs(size_t ms);
-  void resetState();
+  void resetState(bool paused = false);
 
   // Vorbis codec callbacks
   size_t _vorbisRead(void* ptr, size_t size, size_t nmemb);
@@ -89,6 +89,7 @@ class TrackPlayer : bell::Task {
   std::atomic<bool> pendingReset = false;
   std::atomic<bool> inFuture = false;
   std::atomic<size_t> pendingSeekPositionMs = 0;
+  std::atomic<bool> startPaused = false;
 
   std::mutex runningMutex;
 

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -77,6 +77,12 @@ void SpircHandler::subscribeToMercury() {
 
 void SpircHandler::loadTrackFromURI(const std::string& uri) {}
 
+void SpircHandler::notifyAudioEnded() {
+    playbackState->updatePositionMs(0);
+    notify();
+    trackPlayer->resetState(true);
+}
+
 void SpircHandler::notifyAudioReachedPlayback() {
   int offset = 0;
 

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -36,8 +36,8 @@ SpircHandler::SpircHandler(std::shared_ptr<cspot::Context> ctx) {
     playbackState->updatePositionMs(track->requestedPosition);
 
     this->notify();
-    CSPOT_LOG(info, "WHARE %d", paused);
-    // Send playback start event, unpause
+
+    // Send playback start event, pause/unpause per request
     sendEvent(EventType::PLAYBACK_START, (int)track->requestedPosition);
     sendEvent(EventType::PLAY_PAUSE, paused);
   };

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -87,10 +87,11 @@ void TrackPlayer::stop() {
   std::scoped_lock lock(runningMutex);
 }
 
-void TrackPlayer::resetState() {
+void TrackPlayer::resetState(bool paused) {
   // Mark for reset
   this->pendingReset = true;
   this->currentSongPlaying = false;
+  this->startPaused = paused;
 
   std::scoped_lock lock(dataOutMutex);
 
@@ -184,7 +185,8 @@ void TrackPlayer::runTask() {
       }
 
       if (trackOffset == 0 && pendingSeekPositionMs == 0) {
-        this->trackLoaded(track);
+        this->trackLoaded(track, startPaused);
+        startPaused = false;
       }
 
       int32_t r =

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -119,7 +119,7 @@ void TrackPlayer::runTask() {
   while (isRunning) {
     // Ensure we even have any tracks to play
     if (!this->trackQueue->hasTracks() ||
-        (endOfQueueReached && trackQueue->isFinished())) {
+        (!pendingReset && endOfQueueReached && trackQueue->isFinished())) {
       this->trackQueue->playableSemaphore->twait(300);
       continue;
     }

--- a/cspot/src/TrackQueue.cpp
+++ b/cspot/src/TrackQueue.cpp
@@ -553,6 +553,13 @@ bool TrackQueue::skipTrack(SkipDirection dir, bool expectNotify) {
     }
 
     return true;
+  } else if (dir == SkipDirection::PREV && currentTracksIndex == 0) {
+      queueNextTrack(0);
+
+      // Reset position to zero (in that case it's always expected)
+      notifyPending = true;
+
+      return true;
   }
 
   return false;

--- a/cspot/src/TrackQueue.cpp
+++ b/cspot/src/TrackQueue.cpp
@@ -522,10 +522,10 @@ bool TrackQueue::queueNextTrack(int offset, uint32_t positionMs) {
 bool TrackQueue::skipTrack(SkipDirection dir, bool expectNotify) {
   bool canSkipNext = currentTracks.size() > currentTracksIndex + 1;
   bool canSkipPrev = currentTracksIndex > 0;
-  uint64_t position = !playbackState->remoteFrame.state.has_position_ms ? 0 :
-      playbackState->remoteFrame.state.position_ms +
+  uint64_t position = !playbackState->innerFrame.state.has_position_ms ? 0 :
+      playbackState->innerFrame.state.position_ms +
       ctx->timeProvider->getSyncedTimestamp() -
-      playbackState->remoteFrame.state.position_measured_at;
+      playbackState->innerFrame.state.position_measured_at;
 
   if (dir == SkipDirection::PREV && (currentTracksIndex == 0 || position > 3000)) {
       queueNextTrack(0);

--- a/cspot/src/TrackReference.cpp
+++ b/cspot/src/TrackReference.cpp
@@ -24,11 +24,7 @@ void TrackReference::decodeURI() {
       gid = bigNumAdd(gid, d);
     }
 
-#if __cplusplus >= 202002L
-    if (uri.starts_with("episode")) {
-#else
-    if (uri.find("episode") == 0) {
-#endif
+    if (uri.find("episode:") != std::string::npos) {
       type = Type::EPISODE;
     }
   }

--- a/targets/cli/CliPlayer.cpp
+++ b/targets/cli/CliPlayer.cpp
@@ -66,7 +66,11 @@ CliPlayer::CliPlayer(std::unique_ptr<AudioSink> sink,
             break;
           case cspot::SpircHandler::EventType::PLAYBACK_START:
             this->isPaused = true;
+            this->playlistEnd = false;
             this->centralAudioBuffer->clearBuffer();
+            break;
+          case cspot::SpircHandler::EventType::DEPLETED:
+            this->playlistEnd = true;
             break;
           default:
             break;
@@ -102,6 +106,10 @@ void CliPlayer::runTask() {
       }
 
       if (!chunk || chunk->pcmSize == 0) {
+        if (this->playlistEnd) {
+            this->handler->notifyAudioEnded();
+            this->playlistEnd = false;
+        }
         BELL_SLEEP_MS(10);
         continue;
       } else {

--- a/targets/cli/CliPlayer.cpp
+++ b/targets/cli/CliPlayer.cpp
@@ -65,6 +65,7 @@ CliPlayer::CliPlayer(std::unique_ptr<AudioSink> sink,
             this->centralAudioBuffer->clearBuffer();
             break;
           case cspot::SpircHandler::EventType::PLAYBACK_START:
+            this->isPaused = true;
             this->centralAudioBuffer->clearBuffer();
             break;
           default:
@@ -90,7 +91,7 @@ void CliPlayer::runTask() {
 
       if (this->pauseRequested) {
         this->pauseRequested = false;
-        std::cout << "Pause requsted!" << std::endl;
+        std::cout << "Pause requested!" << std::endl;
 #ifndef BELL_DISABLE_CODECS
         auto effect = std::make_unique<bell::BellDSP::FadeEffect>(
             44100 / 2, false, [this]() { this->isPaused = true; });

--- a/targets/cli/CliPlayer.h
+++ b/targets/cli/CliPlayer.h
@@ -37,6 +37,7 @@ class CliPlayer : public bell::Task {
   std::atomic<bool> isPaused = true;
   std::atomic<bool> isRunning = true;
   std::mutex runningMutex;
+  std::atomic<bool> playlistEnd = false;
 
   void runTask() override;
 };


### PR DESCRIPTION
There is a string search for "episode" at the beginning of track's URI. I added something a while ago for compiler that are not "fully" C++20 and don't have `start_with` method. But it seems that the URI is now `spotify::episode:`. 

So I just did a general search for `episode:` instead of forcing it to start with it. Feel free to change it to something different, I don't know what the URI should exactly be (but a regex maybe an issue due to what regex drains with in term of C++ code)

[edit]: I've also added another fix when user pressed "PREV" already on 1st track. The state machine was getting lost, pausing the player and ending in a dead lock. I've also added the usual behavior that if we are more than 3 sec in a track, we restart it instead of going to previous. I'm not sure if we should use innerframe or remoteframe or if this matter in that case. 

I've also fixed what happens when pressing NEXT and PREV on last track (or when NEXT track fails). Probably complicated to explain, but the previous logic pausing and resuming to 0 did not work. The logic now is simply abort and reload current track when NEXT fails for any reason. Previously:
- Because the TrackPlayer continues to run and was not seeked to 0 (which is not possible, you can only seek > 0), when pressing PLAY (after a NEXT on last track...), we would resume where we stopped, des-synchronizing with Spotify UI
- if PREV or NEXT was pressed after last track's EOF has been reached, we end-up blocked because the TrackPlayer is in EndOfQueue and isFinished() state, so it will not restart, whatever you do, which was an odd response for user. You'd need to start another track to play again. TrackPlayer must also consider pendingReset before looping on endofqueue/isfinished
- Also, if PREV/NEXT fails, there is no need to send and event

I've also removed some redundant calls in skipTrack because I think that now TrackPlayer does the job of sending PLAY/PAUSE, changing inner status and notify(), so there is no reason to do it in skipTrack which is much more simple.

It's a bit more code changes that I'd like but it's not behavior changes for normal playback. I think stopping on a failed skip event but being able to press "PLAY" and restart the current track is the expected behavior. You could still send the NEXT/PREV event even in case of failure, but I'm not sure I see the point anymore as "PLAYBACK_START" will be sent which causes the player to reset.

Note that I've changed the cli example a bit because I think that for consistency, PLAYBACK_START event should **not** start playback, but only be in pause mode and wait for PLAY event.

With these changes, one can argue that "FLUSH" event (that I think I introduced a while ago) is now un-needed as it is only used in "replace frame" 

Last but not least, at the end of a playlist, there was no method to end properly, instruct Spotify that we are done and be ready to play again by simply pressing PLAY. I've added spirc::notifyAudioEnded() which nicely use the new resetState to do all that.