### PR TITLE
"replace frame" requires updating position

### DIFF
--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -204,7 +204,10 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       CSPOT_LOG(debug, "Got replace frame");
       playbackState->syncWithRemote();
 
-      trackQueue->updateTracks(playbackState->remoteFrame.state.position_ms,
+      // 1st track is the current one, but update the position
+      trackQueue->updateTracks(playbackState->remoteFrame.state.position_ms +
+                               ctx->timeProvider->getSyncedTimestamp() -
+                               playbackState->innerFrame.state.position_measured_at,
                                false);
       this->notify();
 

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -207,8 +207,8 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       // 1st track is the current one, but update the position
       trackQueue->updateTracks(
           playbackState->remoteFrame.state.position_ms +
-            ctx->timeProvider->getSyncedTimestamp() -
-            playbackState->innerFrame.state.position_measured_at,
+              ctx->timeProvider->getSyncedTimestamp() -
+              playbackState->innerFrame.state.position_measured_at,
           false);
 
       this->notify();

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -205,10 +205,12 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       playbackState->syncWithRemote();
 
       // 1st track is the current one, but update the position
-      trackQueue->updateTracks(playbackState->remoteFrame.state.position_ms +
-                               ctx->timeProvider->getSyncedTimestamp() -
-                               playbackState->innerFrame.state.position_measured_at,
-                               false);
+      trackQueue->updateTracks(
+          playbackState->remoteFrame.state.position_ms +
+            ctx->timeProvider->getSyncedTimestamp() -
+            playbackState->innerFrame.state.position_measured_at,
+          false);
+
       this->notify();
 
       sendEvent(EventType::FLUSH);


### PR DESCRIPTION
When a "replace frame" request is received, the current track is part of the updated tracks list and cspot forces a reload at the current position. But the position is what is in frame's state, and it's not taking into account elapsed time since last measure.

FLUSH is a bit of a weird event meaning that after it, we'll get PLAYBACK_START and PLAY_PAUSE as usual but we shall **NOT** call notifyAudioReachedPlayback and thus we won't get TRACK_INFO. I guess it's ... flush, i.e. everything will restart the same so you can keep what you have memorized. I understand why you need to reload the current track as the n+1 might already be in buffers and we want to flush everything >= n+1, but it means that there is an audio interruption every time we add/remove something from the queue. I guess otherwise FLUSH would have to have a different meaning, i.e. "get rid of everything except the current track" and that's complicated. 

Anyway, please don't change that now 😄 but I originally missed the idea.

NB: There is still a mysterious case where the current track might not be re-sent in the list by Spotify but I can't find a way to reproduce that. It does not seem linked to the fact that the current track has already been fully received or not.