### PR TITLE
do not reload track when changing queue (if possible)

### DIFF
--- a/cspot/include/TrackPlayer.h
+++ b/cspot/include/TrackPlayer.h
@@ -50,9 +50,6 @@ class TrackPlayer : bell::Task {
   // CDNTrackStream::TrackInfo getCurrentTrackInfo();
   void seekMs(size_t ms);
   void resetState(bool paused = false);
-  std::shared_ptr<QueuedTrack> getCurrentTrack() {
-      return track;
-  };
 
   // Vorbis codec callbacks
   size_t _vorbisRead(void* ptr, size_t size, size_t nmemb);
@@ -67,7 +64,6 @@ class TrackPlayer : bell::Task {
   std::shared_ptr<cspot::Context> ctx;
   std::shared_ptr<cspot::TrackQueue> trackQueue;
   std::shared_ptr<cspot::CDNAudioFile> currentTrackStream;
-  std::shared_ptr<QueuedTrack> track = nullptr;
 
   std::unique_ptr<bell::WrappedSemaphore> playbackSemaphore;
 

--- a/cspot/include/TrackPlayer.h
+++ b/cspot/include/TrackPlayer.h
@@ -37,7 +37,6 @@ class TrackPlayer : bell::Task {
   typedef std::function<size_t(uint8_t*, size_t, std::string_view)>
       DataCallback;
   typedef std::function<void()> EOFCallback;
-  typedef std::function<bool()> isAiringCallback;
 
   TrackPlayer(std::shared_ptr<cspot::Context> ctx,
               std::shared_ptr<cspot::TrackQueue> trackQueue,
@@ -51,6 +50,9 @@ class TrackPlayer : bell::Task {
   // CDNTrackStream::TrackInfo getCurrentTrackInfo();
   void seekMs(size_t ms);
   void resetState(bool paused = false);
+  std::shared_ptr<QueuedTrack> getCurrentTrack() {
+      return track;
+  };
 
   // Vorbis codec callbacks
   size_t _vorbisRead(void* ptr, size_t size, size_t nmemb);
@@ -65,6 +67,7 @@ class TrackPlayer : bell::Task {
   std::shared_ptr<cspot::Context> ctx;
   std::shared_ptr<cspot::TrackQueue> trackQueue;
   std::shared_ptr<cspot::CDNAudioFile> currentTrackStream;
+  std::shared_ptr<QueuedTrack> track = nullptr;
 
   std::unique_ptr<bell::WrappedSemaphore> playbackSemaphore;
 

--- a/cspot/include/TrackQueue.h
+++ b/cspot/include/TrackQueue.h
@@ -54,6 +54,7 @@ class QueuedTrack {
 
   uint32_t requestedPosition;
   std::string identifier;
+  bool loading = false;
 
   // Will return nullptr if the track is not ready
   std::shared_ptr<cspot::CDNAudioFile> getAudioFile();
@@ -100,7 +101,7 @@ class TrackQueue : public bell::Task {
   bool hasTracks();
   bool isFinished();
   bool skipTrack(SkipDirection dir, bool expectNotify = true);
-  bool updateTracks(uint32_t requestedPosition = 0, std::function<TrackReference()> getCurrentRef = nullptr);
+  bool updateTracks(uint32_t requestedPosition = 0, bool initial = false);
   TrackInfo getTrackInfo(std::string_view identifier);
   std::shared_ptr<QueuedTrack> consumeTrack(
       std::shared_ptr<QueuedTrack> prevSong, int& offset);

--- a/cspot/include/TrackQueue.h
+++ b/cspot/include/TrackQueue.h
@@ -100,7 +100,7 @@ class TrackQueue : public bell::Task {
   bool hasTracks();
   bool isFinished();
   bool skipTrack(SkipDirection dir, bool expectNotify = true);
-  void updateTracks(uint32_t requestedPosition = 0, bool initial = false);
+  bool updateTracks(uint32_t requestedPosition = 0, std::function<TrackReference()> getCurrentRef = nullptr);
   TrackInfo getTrackInfo(std::string_view identifier);
   std::shared_ptr<QueuedTrack> consumeTrack(
       std::shared_ptr<QueuedTrack> prevSong, int& offset);

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -192,7 +192,7 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
 
       // Update track list in case we have a new one
       trackQueue->updateTracks(playbackState->remoteFrame.state.position_ms,
-                               nullptr);
+                               true);
 
       this->notify();
 
@@ -208,10 +208,7 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       bool cleared = trackQueue->updateTracks(
           playbackState->remoteFrame.state.position_ms +
           ctx->timeProvider->getSyncedTimestamp() -
-          playbackState->innerFrame.state.position_measured_at,
-          [this] () {
-              return trackPlayer->getCurrentTrack()->ref;
-          } );
+          playbackState->innerFrame.state.position_measured_at);
 
       this->notify();
 

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -201,7 +201,7 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       break;
     }
     case MessageType_kMessageTypeReplace: {
-      CSPOT_LOG(debug, "Got replace frame");
+      CSPOT_LOG(debug, "Got replace frame %d", playbackState->remoteTracks.size());
       playbackState->syncWithRemote();
 
       // 1st track is the current one, but update the position

--- a/cspot/src/SpircHandler.cpp
+++ b/cspot/src/SpircHandler.cpp
@@ -201,21 +201,23 @@ void SpircHandler::handleFrame(std::vector<uint8_t>& data) {
       break;
     }
     case MessageType_kMessageTypeReplace: {
-      CSPOT_LOG(debug, "Got replace frame %d", playbackState->remoteTracks.size());
+      CSPOT_LOG(debug, "Got replace frame %d",
+                playbackState->remoteTracks.size());
       playbackState->syncWithRemote();
 
       // 1st track is the current one, but update the position
       bool cleared = trackQueue->updateTracks(
           playbackState->remoteFrame.state.position_ms +
-          ctx->timeProvider->getSyncedTimestamp() -
-          playbackState->innerFrame.state.position_measured_at, false);
+              ctx->timeProvider->getSyncedTimestamp() -
+              playbackState->innerFrame.state.position_measured_at,
+          false);
 
       this->notify();
 
       // need to re-load all if streaming track is completed
       if (cleared) {
-          sendEvent(EventType::FLUSH);
-          trackPlayer->resetState();
+        sendEvent(EventType::FLUSH);
+        trackPlayer->resetState();
       }
       break;
     }

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -111,7 +111,7 @@ void TrackPlayer::seekMs(size_t ms) {
 void TrackPlayer::runTask() {
   std::scoped_lock lock(runningMutex);
 
-  std::shared_ptr<QueuedTrack> track, newTrack = nullptr;
+  std::shared_ptr<QueuedTrack> newTrack = nullptr;
 
   int trackOffset = 0;
   bool eof = false;

--- a/cspot/src/TrackPlayer.cpp
+++ b/cspot/src/TrackPlayer.cpp
@@ -111,7 +111,7 @@ void TrackPlayer::seekMs(size_t ms) {
 void TrackPlayer::runTask() {
   std::scoped_lock lock(runningMutex);
 
-  std::shared_ptr<QueuedTrack> newTrack = nullptr;
+  std::shared_ptr<QueuedTrack> track, newTrack = nullptr;
 
   int trackOffset = 0;
   bool eof = false;
@@ -201,6 +201,7 @@ void TrackPlayer::runTask() {
       }
 
       eof = false;
+      track->loading = true;
 
       CSPOT_LOG(info, "Playing");
 
@@ -255,6 +256,7 @@ void TrackPlayer::runTask() {
 
       // always move back to LOADING (ensure proper seeking after last track has been loaded)
       currentTrackStream = nullptr;
+      track->loading = false;
     }
 
     if (eof) {

--- a/cspot/src/TrackQueue.cpp
+++ b/cspot/src/TrackQueue.cpp
@@ -609,16 +609,16 @@ bool TrackQueue::updateTracks(uint32_t requestedPosition, bool initial) {
 
     playableSemaphore->give();
   } else if (preloadedTracks[0]->loading) {
-      // try to not re-load track if we are still loading it
-   
-      // remove everything except first track
-      preloadedTracks.erase(preloadedTracks.begin() + 1, preloadedTracks.end());
+    // try to not re-load track if we are still loading it
 
-      // Push a song on the preloaded queue
-      CSPOT_LOG(info, "Keeping current track %d", currentTracksIndex);
-      queueNextTrack(1);
+    // remove everything except first track
+    preloadedTracks.erase(preloadedTracks.begin() + 1, preloadedTracks.end());
 
-      cleared = false;
+    // Push a song on the preloaded queue
+    CSPOT_LOG(info, "Keeping current track %d", currentTracksIndex);
+    queueNextTrack(1);
+
+    cleared = false;
   } else {
     // Clear preloaded tracks
     preloadedTracks.clear();

--- a/targets/cli/CliPlayer.cpp
+++ b/targets/cli/CliPlayer.cpp
@@ -26,7 +26,7 @@ CliPlayer::CliPlayer(std::unique_ptr<AudioSink> sink,
   this->audioSink = std::move(sink);
 
   this->centralAudioBuffer =
-      std::make_shared<bell::CentralAudioBuffer>(1 * 1024);
+      std::make_shared<bell::CentralAudioBuffer>(128 * 1024);
 
 #ifndef BELL_DISABLE_CODECS
   this->dsp = std::make_shared<bell::BellDSP>(this->centralAudioBuffer);

--- a/targets/cli/CliPlayer.cpp
+++ b/targets/cli/CliPlayer.cpp
@@ -26,7 +26,7 @@ CliPlayer::CliPlayer(std::unique_ptr<AudioSink> sink,
   this->audioSink = std::move(sink);
 
   this->centralAudioBuffer =
-      std::make_shared<bell::CentralAudioBuffer>(128 * 1024);
+      std::make_shared<bell::CentralAudioBuffer>(1 * 1024);
 
 #ifndef BELL_DISABLE_CODECS
   this->dsp = std::make_shared<bell::BellDSP>(this->centralAudioBuffer);
@@ -72,6 +72,10 @@ CliPlayer::CliPlayer(std::unique_ptr<AudioSink> sink,
           case cspot::SpircHandler::EventType::DEPLETED:
             this->playlistEnd = true;
             break;
+          case cspot::SpircHandler::EventType::VOLUME: {
+            int volume = std::get<int>(event->data);
+            break;
+          }
           default:
             break;
         }


### PR DESCRIPTION
When the user update the queue, Spotify sends a "replace" frame but one issue is that the current (playing) track is being stopped and reloaded which caused and audible gap, especially on esp32.

This PR tries to address the issue when possible, means that when the 1st track of the reloaded frame is still being played, then no reload is done. Of course, why large buffers, the windows when this can be done will be smaller as TrackPlayer quickly moves to streaming the next track and it becomes virtually impossible to distinguish between tracks.

This probably needs a thorough review

[edit]: I did a first version that poke the TrackPlayer to know what it was playing but it was a bit goofy and I think it's better now where the TrackPlayer simply sets a flag on the track it is downloading and if the preloadedTracks[0] has that flag set, then it simply means that we are still on it. Less changes to different places of the code.