### PR TITLE
feat(esp32s3): LVGL display, FT6336 touch and SHT31 sensor for ES3C28P board

### DIFF
--- a/cspot/src/TrackQueue.cpp
+++ b/cspot/src/TrackQueue.cpp
@@ -305,6 +305,10 @@ void QueuedTrack::stepLoadCDNUrl(const std::string& accessKey) {
     CSPOT_LOG(info, "Received CDN URL, %s", cdnUrl.c_str());
     state = State::READY;
     loadedSemaphore->give();
+  } catch (std::exception& e) {
+    CSPOT_LOG(error, "Cannot fetch CDN URL: %s", e.what());
+    state = State::FAILED;
+    loadedSemaphore->give();
   } catch (...) {
     CSPOT_LOG(error, "Cannot fetch CDN URL");
     state = State::FAILED;

--- a/targets/esp32/CMakeLists.txt
+++ b/targets/esp32/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 3.5)
 # Don't override EXTRA_COMPONENT_DIRS as platformio uses it.  Instead we append
 # see https://github.com/platformio/platform-espressif32/issues/341
 list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/led_strip)
 
 if(NOT IDF_NO_INCLUDE)
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/targets/esp32/dependencies.lock
+++ b/targets/esp32/dependencies.lock
@@ -1,0 +1,104 @@
+dependencies:
+  espressif/cmake_utilities:
+    component_hash: 351350613ceafba240b761b4ea991e0f231ac7a9f59a9ee901f751bddc0bb18f
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 0.5.3
+  espressif/esp_lcd_ili9341:
+    component_hash: 0baab584e0e490511d6bdbae6aa045130424d732ecdaad6cd1d3bd3c0abe2c30
+    dependencies:
+    - name: espressif/cmake_utilities
+      registry_url: https://components.espressif.com
+      require: private
+      version: 0.*
+    - name: idf
+      require: private
+      version: '>=4.4'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 2.0.2
+  espressif/esp_lcd_touch:
+    component_hash: 3f85a7d95af876f1a6ecca8eb90a81614890d0f03a038390804e5a77e2caf862
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.4.2'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.2.1
+  espressif/esp_lcd_touch_ft5x06:
+    component_hash: 8ae101b4a321b6327d98751b049e3c7fff2718ad04d676259369ff85d4edbcdf
+    dependencies:
+    - name: espressif/esp_lcd_touch
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^1.2.0
+    - name: idf
+      require: private
+      version: '>=5.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0~1
+  espressif/esp_lvgl_port:
+    component_hash: fb6c1fdfe70d4ca39a035d63ca394a35f17ec84ce16ff98ecb13a54155d75da4
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.2'
+    - name: lvgl/lvgl
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=8,<10'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 2.8.0~1
+  espressif/led_strip:
+    component_hash: 28621486f77229aaf81c71f5e15d6fbf36c2949cf11094e07090593e659e7639
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 3.0.3
+  espressif/mdns:
+    component_hash: e81ca7a7f53ea34e78274df054da692c272e1315572876b237b1748e267c013b
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.11.3
+  idf:
+    source:
+      type: idf
+    version: 5.3.3
+  lvgl/lvgl:
+    component_hash: 184e532558c1c45fefed631f3e235423d22582aafb4630f3e8885c35281a49ae
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 9.5.0
+direct_dependencies:
+- espressif/esp_lcd_ili9341
+- espressif/esp_lcd_touch_ft5x06
+- espressif/esp_lvgl_port
+- espressif/led_strip
+- espressif/mdns
+- lvgl/lvgl
+manifest_hash: 76f021b2273d4e5113d58721d2afdd4bbc65d8de39165855c83b5b690f309167
+target: esp32s3
+version: 2.0.0

--- a/targets/esp32/main/board_display.c
+++ b/targets/esp32/main/board_display.c
@@ -103,6 +103,7 @@ void board_display_init(void) {
   esp_lcd_panel_io_handle_t tp_io_handle = NULL;
   esp_lcd_panel_io_i2c_config_t tp_io_cfg =
       ESP_LCD_TOUCH_IO_I2C_FT5x06_CONFIG();
+  tp_io_cfg.scl_speed_hz = 0;  // driver i2c legado: lo rechaza si != 0
   ESP_ERROR_CHECK(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)I2C_PORT,
                                            &tp_io_cfg, &tp_io_handle));
 

--- a/targets/esp32/main/board_display.c
+++ b/targets/esp32/main/board_display.c
@@ -1,0 +1,159 @@
+// Pantalla 2.8" IPS ILI9341V + touch FT6336G de la placa ES3C28P/ES3N28P.
+// Pines tomados del demo del fabricante (2.8inch_ESP32-S3_LVGL):
+//   SPI2: MOSI=11 CLK=12 MISO=13 CS=10 DC=46 RST=18, backlight=45 (activo alto)
+//   I2C0: SDA=16 SCL=15 (compartido con codec ES8311 y sensor SHT31)
+//   Landscape 320x240: MADCTL 0x28 -> swap_xy, sin mirror, orden BGR,
+//   colores invertidos (panel IPS).
+
+#include "board_display.h"
+
+#include "driver/gpio.h"
+#include "driver/i2c.h"
+#include "driver/spi_master.h"
+#include "esp_lcd_ili9341.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_touch_ft5x06.h"
+#include "esp_log.h"
+#include "esp_lvgl_port.h"
+
+#define LCD_HOST SPI2_HOST
+#define PIN_LCD_MOSI 11
+#define PIN_LCD_CLK 12
+#define PIN_LCD_MISO 13
+#define PIN_LCD_CS 10
+#define PIN_LCD_DC 46
+#define PIN_LCD_RST 18
+#define PIN_LCD_BCKL 45
+
+#define I2C_PORT I2C_NUM_0
+#define PIN_I2C_SDA 16
+#define PIN_I2C_SCL 15
+
+#define LCD_H_RES 320
+#define LCD_V_RES 240
+
+static const char* TAG = "board_display";
+
+// Instala el driver I2C legado en el puerto 0. El ES8311 (bell) reutiliza
+// este bus: su I2cInit tolera el driver ya instalado.
+static void board_i2c_init(void) {
+  i2c_config_t cfg = {
+      .mode = I2C_MODE_MASTER,
+      .sda_io_num = PIN_I2C_SDA,
+      .scl_io_num = PIN_I2C_SCL,
+      .sda_pullup_en = GPIO_PULLUP_ENABLE,
+      .scl_pullup_en = GPIO_PULLUP_ENABLE,
+      .master = {.clk_speed = 100000},
+  };
+  ESP_ERROR_CHECK(i2c_param_config(I2C_PORT, &cfg));
+  ESP_ERROR_CHECK(i2c_driver_install(I2C_PORT, cfg.mode, 0, 0, 0));
+}
+
+void board_display_init(void) {
+  board_i2c_init();
+
+  // Backlight apagado durante el init para no mostrar basura
+  gpio_config_t bk_cfg = {
+      .pin_bit_mask = 1ULL << PIN_LCD_BCKL,
+      .mode = GPIO_MODE_OUTPUT,
+  };
+  ESP_ERROR_CHECK(gpio_config(&bk_cfg));
+  gpio_set_level(PIN_LCD_BCKL, 0);
+
+  spi_bus_config_t bus_cfg = {
+      .mosi_io_num = PIN_LCD_MOSI,
+      .miso_io_num = PIN_LCD_MISO,
+      .sclk_io_num = PIN_LCD_CLK,
+      .quadwp_io_num = -1,
+      .quadhd_io_num = -1,
+      .max_transfer_sz = LCD_H_RES * 40 * sizeof(uint16_t),
+  };
+  ESP_ERROR_CHECK(spi_bus_initialize(LCD_HOST, &bus_cfg, SPI_DMA_CH_AUTO));
+
+  esp_lcd_panel_io_handle_t io_handle = NULL;
+  esp_lcd_panel_io_spi_config_t io_cfg = {
+      .cs_gpio_num = PIN_LCD_CS,
+      .dc_gpio_num = PIN_LCD_DC,
+      .spi_mode = 0,
+      .pclk_hz = 40 * 1000 * 1000,
+      .trans_queue_depth = 10,
+      .lcd_cmd_bits = 8,
+      .lcd_param_bits = 8,
+  };
+  ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)LCD_HOST,
+                                           &io_cfg, &io_handle));
+
+  esp_lcd_panel_handle_t panel_handle = NULL;
+  esp_lcd_panel_dev_config_t panel_cfg = {
+      .reset_gpio_num = PIN_LCD_RST,
+      .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
+      .bits_per_pixel = 16,
+  };
+  ESP_ERROR_CHECK(
+      esp_lcd_new_panel_ili9341(io_handle, &panel_cfg, &panel_handle));
+  ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
+  ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
+  ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel_handle, true));
+  ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, true));
+  ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, false, false));
+  ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
+
+  // Touch FT6336G (compatible FT5x06) por I2C legado, sin INT: polling
+  esp_lcd_panel_io_handle_t tp_io_handle = NULL;
+  esp_lcd_panel_io_i2c_config_t tp_io_cfg =
+      ESP_LCD_TOUCH_IO_I2C_FT5x06_CONFIG();
+  ESP_ERROR_CHECK(esp_lcd_new_panel_io_i2c((esp_lcd_i2c_bus_handle_t)I2C_PORT,
+                                           &tp_io_cfg, &tp_io_handle));
+
+  esp_lcd_touch_handle_t tp = NULL;
+  esp_lcd_touch_config_t tp_cfg = {
+      .x_max = LCD_H_RES,
+      .y_max = LCD_V_RES,
+      .rst_gpio_num = -1,
+      .int_gpio_num = -1,
+      .flags =
+          {
+              // Equivalente a SWAPXY + INVERT_Y del demo
+              .swap_xy = 1,
+              .mirror_x = 0,
+              .mirror_y = 1,
+          },
+  };
+  ESP_ERROR_CHECK(esp_lcd_touch_new_i2c_ft5x06(tp_io_handle, &tp_cfg, &tp));
+
+  const lvgl_port_cfg_t port_cfg = ESP_LVGL_PORT_INIT_CONFIG();
+  ESP_ERROR_CHECK(lvgl_port_init(&port_cfg));
+
+  const lvgl_port_display_cfg_t disp_cfg = {
+      .io_handle = io_handle,
+      .panel_handle = panel_handle,
+      .buffer_size = LCD_H_RES * 24,
+      .double_buffer = true,
+      .hres = LCD_H_RES,
+      .vres = LCD_V_RES,
+      .monochrome = false,
+      .rotation =
+          {
+              .swap_xy = true,
+              .mirror_x = false,
+              .mirror_y = false,
+          },
+      .color_format = LV_COLOR_FORMAT_RGB565,
+      .flags =
+          {
+              .buff_dma = true,
+              .swap_bytes = true,
+          },
+  };
+  lv_display_t* disp = lvgl_port_add_disp(&disp_cfg);
+
+  const lvgl_port_touch_cfg_t touch_cfg = {
+      .disp = disp,
+      .handle = tp,
+  };
+  lvgl_port_add_touch(&touch_cfg);
+
+  gpio_set_level(PIN_LCD_BCKL, 1);
+  ESP_LOGI(TAG, "Pantalla + touch listos");
+}

--- a/targets/esp32/main/board_display.h
+++ b/targets/esp32/main/board_display.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Inicializa I2C0 compartido (SDA=16, SCL=15), SPI + panel ILI9341V,
+// touch FT6336G y el port LVGL (tarea + tick). Llamar una sola vez
+// antes de crear la UI.
+void board_display_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/esp32/main/idf_component.yml
+++ b/targets/esp32/main/idf_component.yml
@@ -1,0 +1,7 @@
+dependencies:
+  espressif/mdns: "*"
+  espressif/led_strip: "*"
+  lvgl/lvgl: "^9.2.0"
+  espressif/esp_lvgl_port: "^2.4.0"
+  espressif/esp_lcd_ili9341: "^2.0.0"
+  espressif/esp_lcd_touch_ft5x06: "^1.0.6"

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -36,6 +36,7 @@
 #include "board_display.h"
 #include "sht31.h"
 #include "ui.h"
+#include "wifi_ui.h"
 #include "Logger.h"
 #include "freertos/ringbuf.h"
 #include "freertos/task.h"
@@ -431,10 +432,10 @@ void app_main(void) {
 
   // statusLed->setStatus(StatusLed::WIFI_CONNECTING);
 
-  esp_wifi_set_ps(WIFI_PS_NONE);
   ESP_ERROR_CHECK(esp_netif_init());
   ESP_ERROR_CHECK(esp_event_loop_create_default());
-  ESP_ERROR_CHECK(example_connect());
+  // Conexion con credenciales guardadas o portal tactil en pantalla
+  wifi_ui_connect();
 
   // statusLed->setStatus(StatusLed::WIFI_CONNECTED);
 

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -38,6 +38,7 @@
 #include "ui.h"
 #include "wifi_ui.h"
 #include "Logger.h"
+#include "freertos/queue.h"
 #include "freertos/ringbuf.h"
 #include "freertos/task.h"
 
@@ -78,6 +79,26 @@ class CSpotPlayer : public bell::Task {
   std::unique_ptr<ES8311AudioSink> audioSink;
   std::unique_ptr<bell::CircularBuffer> circularBuffer;
   std::atomic<bool> isPaused;
+
+  static inline QueueHandle_t uiCmdQueue = nullptr;
+
+  static void uiCmdTask(void* arg) {
+    auto* self = static_cast<CSpotPlayer*>(arg);
+    ui_command_t cmd;
+    while (xQueueReceive(uiCmdQueue, &cmd, portMAX_DELAY)) {
+      switch (cmd) {
+        case UI_CMD_PLAY_PAUSE:
+          self->handler->setPause(!self->isPaused);
+          break;
+        case UI_CMD_NEXT:
+          self->handler->nextSong();
+          break;
+        case UI_CMD_PREV:
+          self->handler->previousSong();
+          break;
+      }
+    }
+  }
 
  public:
   CSpotPlayer(std::shared_ptr<cspot::SpircHandler> handler)
@@ -127,20 +148,14 @@ class CSpotPlayer : public bell::Task {
           }
         });
 
-    // Botones táctiles -> comandos Spotify (corre en la tarea LVGL)
+    // Botones táctiles: la tarea LVGL solo encola; una tarea propia ejecuta
+    // los comandos Spotify (protobuf+cifrado+red desbordan el stack de LVGL)
+    uiCmdQueue = xQueueCreate(4, sizeof(ui_command_t));
+    xTaskCreatePinnedToCore(uiCmdTask, "ui_cmd", 8192, this, 5, nullptr, 0);
     ui_set_control_cb(
         [](ui_command_t cmd, void* user) {
-          auto* self = static_cast<CSpotPlayer*>(user);
-          switch (cmd) {
-            case UI_CMD_PLAY_PAUSE:
-              self->handler->setPause(!self->isPaused);
-              break;
-            case UI_CMD_NEXT:
-              self->handler->nextSong();
-              break;
-            case UI_CMD_PREV:
-              self->handler->previousSong();
-              break;
+          if (uiCmdQueue) {
+            xQueueSend(uiCmdQueue, &cmd, 0);
           }
         },
         this);
@@ -236,24 +251,29 @@ class CSpotTask : public bell::Task {
 
     BELL_LOG(info, "cspot", "Got blob!");
     if (gotBlob) {
-      auto ctx = cspot::Context::createFromBlob(blob);
-      CSPOT_LOG(info, "Creating player");
-      ctx->session->connectWithRandomAp();
-      auto token = ctx->session->authenticate(blob);
+      try {
+        auto ctx = cspot::Context::createFromBlob(blob);
+        CSPOT_LOG(info, "Creating player");
+        ctx->session->connectWithRandomAp();
+        auto token = ctx->session->authenticate(blob);
 
-      // Auth successful
-      if (token.size() > 0) {
-        ctx->session->startTask();
-        auto handler = std::make_shared<cspot::SpircHandler>(ctx);
-        handler->subscribeToMercury();
-        auto player = std::make_shared<CSpotPlayer>(handler);
+        // Auth successful
+        if (token.size() > 0) {
+          ctx->session->startTask();
+          auto handler = std::make_shared<cspot::SpircHandler>(ctx);
+          handler->subscribeToMercury();
+          auto player = std::make_shared<CSpotPlayer>(handler);
 
-        while (true) {
-          ctx->session->handlePacket();
+          while (true) {
+            ctx->session->handlePacket();
+          }
+
+          handler->disconnect();
+          //   player->disconnect();
         }
-
-        handler->disconnect();
-        //   player->disconnect();
+      } catch (std::exception& e) {
+        BELL_LOG(error, "cspot", "Fallo del player: %s", e.what());
+        ui_set_status("Error Spotify — reinicia la placa");
       }
     }
   }

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -24,6 +24,7 @@
 #include <CSpotContext.h>
 #include <LoginBlob.h>
 #include <SpircHandler.h>
+#include <TrackPlayer.h>
 
 #include <inttypes.h>
 #include "BellTask.h"
@@ -32,6 +33,9 @@
 #include "BellUtils.h"
 #include "ES8311AudioSink.h"
 #include "ESPStatusLed.h"
+#include "board_display.h"
+#include "sht31.h"
+#include "ui.h"
 #include "Logger.h"
 #include "freertos/ringbuf.h"
 #include "freertos/task.h"
@@ -86,7 +90,9 @@ class CSpotPlayer : public bell::Task {
         std::make_unique<bell::CircularBuffer>(1024 * 128 * 8);
 
     this->handler->getTrackPlayer()->setDataCallback(
-        [this](uint8_t* data, size_t bytes) { this->feedData(data, bytes); });
+        [this](uint8_t* data, size_t bytes, std::string_view trackId) {
+          return this->feedData(data, bytes);
+        });
     this->isPaused = false;
 
     this->handler->setEventHandler(
@@ -94,6 +100,16 @@ class CSpotPlayer : public bell::Task {
           switch (event->eventType) {
             case cspot::SpircHandler::EventType::PLAY_PAUSE:
               this->isPaused = std::get<bool>(event->data);
+              ui_set_playing(!this->isPaused);
+              break;
+            case cspot::SpircHandler::EventType::TRACK_INFO: {
+              auto& info = std::get<cspot::TrackInfo>(event->data);
+              ui_set_track(info.name.c_str(), info.artist.c_str());
+              break;
+            }
+            case cspot::SpircHandler::EventType::DISC:
+              ui_set_playing(false);
+              ui_set_status("Desconectado");
               break;
             case cspot::SpircHandler::EventType::FLUSH:
               this->circularBuffer->emptyBuffer();
@@ -103,14 +119,34 @@ class CSpotPlayer : public bell::Task {
               break;
             case cspot::SpircHandler::EventType::PLAYBACK_START:
               this->circularBuffer->emptyBuffer();
+              ui_set_playing(true);
+              ui_set_status("Reproduciendo");
             default:
               break;
           }
         });
+
+    // Botones táctiles -> comandos Spotify (corre en la tarea LVGL)
+    ui_set_control_cb(
+        [](ui_command_t cmd, void* user) {
+          auto* self = static_cast<CSpotPlayer*>(user);
+          switch (cmd) {
+            case UI_CMD_PLAY_PAUSE:
+              self->handler->setPause(!self->isPaused);
+              break;
+            case UI_CMD_NEXT:
+              self->handler->nextSong();
+              break;
+            case UI_CMD_PREV:
+              self->handler->previousSong();
+              break;
+          }
+        },
+        this);
     startTask();
   }
 
-  void feedData(uint8_t* data, size_t len) {
+  size_t feedData(uint8_t* data, size_t len) {
     size_t toWrite = len;
 
     while (toWrite > 0) {
@@ -122,6 +158,8 @@ class CSpotPlayer : public bell::Task {
 
       toWrite -= written;
     }
+
+    return len;
   }
 
   void runTask() {
@@ -151,7 +189,7 @@ class CSpotTask : public bell::Task {
     mdns_hostname_set("cspot");
     std::atomic<bool> gotBlob = false;
 
-    auto blob = std::make_shared<LoginBlob>(DEVICE_NAME);
+    auto blob = std::make_shared<cspot::LoginBlob>(DEVICE_NAME);
 
     auto server = std::make_unique<bell::BellHTTPServer>(8080);
     server->registerGet(
@@ -385,6 +423,12 @@ void app_main(void) {
 
   init_spiffs();
 
+  // Pantalla + UI + sensor antes de la red: feedback inmediato al encender
+  board_display_init();
+  ui_init();
+  sht31_start();
+  ui_set_status("Conectando WiFi...");
+
   // statusLed->setStatus(StatusLed::WIFI_CONNECTING);
 
   esp_wifi_set_ps(WIFI_PS_NONE);
@@ -395,6 +439,7 @@ void app_main(void) {
   // statusLed->setStatus(StatusLed::WIFI_CONNECTED);
 
   ESP_LOGI(TAG, "Connected to AP, start spotify receiver");
+  ui_set_status("Esperando Spotify...");
   //auto taskHandle = xTaskCreatePinnedToCore(&cspotTask, "cspot", 12*1024, NULL, 5, NULL, 1);
   /*auto taskHandle = */
   bell::setDefaultLogger();

--- a/targets/esp32/main/sht31.c
+++ b/targets/esp32/main/sht31.c
@@ -1,0 +1,72 @@
+// Sensor SHT31-D en el bus I2C0 compartido (SDA=16, SCL=15).
+// Lectura single-shot de alta repetibilidad cada 5 s.
+
+#include "sht31.h"
+
+#include "driver/i2c.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "ui.h"
+
+#define SHT31_ADDR 0x44
+#define I2C_PORT I2C_NUM_0
+
+static const char* TAG = "sht31";
+
+// CRC-8 de Sensirion: polinomio 0x31, init 0xFF
+static uint8_t sht31_crc(const uint8_t* data, int len) {
+  uint8_t crc = 0xFF;
+  for (int i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (int b = 0; b < 8; b++) {
+      crc = (crc & 0x80) ? (crc << 1) ^ 0x31 : crc << 1;
+    }
+  }
+  return crc;
+}
+
+static esp_err_t sht31_read(float* temp_c, float* hum_pct) {
+  const uint8_t cmd[2] = {0x24, 0x00};  // single-shot, high repeatability
+  esp_err_t err = i2c_master_write_to_device(I2C_PORT, SHT31_ADDR, cmd, 2,
+                                             pdMS_TO_TICKS(100));
+  if (err != ESP_OK) {
+    return err;
+  }
+  vTaskDelay(pdMS_TO_TICKS(20));  // conversion: max 15 ms
+
+  uint8_t buf[6];
+  err = i2c_master_read_from_device(I2C_PORT, SHT31_ADDR, buf, sizeof(buf),
+                                    pdMS_TO_TICKS(100));
+  if (err != ESP_OK) {
+    return err;
+  }
+  if (sht31_crc(buf, 2) != buf[2] || sht31_crc(buf + 3, 2) != buf[5]) {
+    return ESP_ERR_INVALID_CRC;
+  }
+
+  uint16_t raw_t = (buf[0] << 8) | buf[1];
+  uint16_t raw_h = (buf[3] << 8) | buf[4];
+  *temp_c = -45.0f + 175.0f * (float)raw_t / 65535.0f;
+  *hum_pct = 100.0f * (float)raw_h / 65535.0f;
+  return ESP_OK;
+}
+
+static void sht31_task(void* arg) {
+  int failures = 0;
+  while (1) {
+    float t, h;
+    esp_err_t err = sht31_read(&t, &h);
+    if (err == ESP_OK) {
+      failures = 0;
+      ui_set_env(t, h);
+    } else if (++failures == 3) {
+      ESP_LOGW(TAG, "Lectura SHT31 falla: %s", esp_err_to_name(err));
+    }
+    vTaskDelay(pdMS_TO_TICKS(5000));
+  }
+}
+
+void sht31_start(void) {
+  xTaskCreate(sht31_task, "sht31", 3072, NULL, 3, NULL);
+}

--- a/targets/esp32/main/sht31.h
+++ b/targets/esp32/main/sht31.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Lanza la tarea que lee el SHT31-D (I2C0 compartido, addr 0x44) cada 5 s
+// y publica temperatura/humedad en la UI. Requiere board_display_init().
+void sht31_start(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/esp32/main/ui.c
+++ b/targets/esp32/main/ui.c
@@ -7,6 +7,7 @@
 
 #include "esp_lvgl_port.h"
 #include "lvgl.h"
+#include "wifi_ui.h"
 
 static lv_obj_t* lbl_temp;
 static lv_obj_t* lbl_hum;
@@ -22,7 +23,14 @@ static void btn_event_cb(lv_event_t* e) {
   ui_command_t cmd = (ui_command_t)(uintptr_t)lv_event_get_user_data(e);
   if (control_cb) {
     control_cb(cmd, control_user);
+  } else if (lbl_status) {
+    // Feedback: touch funciona pero aun no hay sesion Spotify
+    lv_label_set_text(lbl_status, "Vincula Spotify primero");
   }
+}
+
+static void wifi_btn_cb(lv_event_t* e) {
+  wifi_ui_open_settings();
 }
 
 static lv_obj_t* make_btn(lv_obj_t* parent, const char* symbol,
@@ -59,6 +67,16 @@ void ui_init(void) {
   lv_obj_set_style_text_color(lbl_hum, lv_color_hex(0x7ec8e3), 0);
   lv_label_set_text(lbl_hum, LV_SYMBOL_TINT " --%");
   lv_obj_align(lbl_hum, LV_ALIGN_TOP_MID, 0, 84);
+
+  // Boton de ajustes WiFi (abre el portal de seleccion de red)
+  lv_obj_t* btn_wifi = lv_button_create(scr);
+  lv_obj_set_size(btn_wifi, 40, 36);
+  lv_obj_set_style_bg_color(btn_wifi, lv_color_hex(0x2a2a2a), 0);
+  lv_obj_align(btn_wifi, LV_ALIGN_TOP_RIGHT, -6, 6);
+  lv_obj_add_event_cb(btn_wifi, wifi_btn_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_t* lbl_wifi = lv_label_create(btn_wifi);
+  lv_label_set_text(lbl_wifi, LV_SYMBOL_WIFI);
+  lv_obj_center(lbl_wifi);
 
   lbl_status = lv_label_create(scr);
   lv_obj_set_style_text_font(lbl_status, &lv_font_montserrat_14, 0);
@@ -115,9 +133,13 @@ void ui_set_env(float temp_c, float hum_pct) {
   if (!lbl_temp) {
     return;
   }
+  // snprintf estandar: el lv_snprintf interno no soporta %f
+  char t[16], h[16];
+  snprintf(t, sizeof(t), "%.1f\xC2\xB0""C", (double)temp_c);
+  snprintf(h, sizeof(h), LV_SYMBOL_TINT " %.0f%%", (double)hum_pct);
   lvgl_port_lock(0);
-  lv_label_set_text_fmt(lbl_temp, "%.1f\xC2\xB0""C", (double)temp_c);
-  lv_label_set_text_fmt(lbl_hum, LV_SYMBOL_TINT " %.0f%%", (double)hum_pct);
+  lv_label_set_text(lbl_temp, t);
+  lv_label_set_text(lbl_hum, h);
   lvgl_port_unlock();
 }
 

--- a/targets/esp32/main/ui.c
+++ b/targets/esp32/main/ui.c
@@ -1,0 +1,150 @@
+// UI LVGL 9: temperatura/humedad grandes arriba, barra Spotify abajo.
+
+#include "ui.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_lvgl_port.h"
+#include "lvgl.h"
+
+static lv_obj_t* lbl_temp;
+static lv_obj_t* lbl_hum;
+static lv_obj_t* lbl_title;
+static lv_obj_t* lbl_artist;
+static lv_obj_t* lbl_status;
+static lv_obj_t* btn_play_label;
+
+static ui_control_cb_t control_cb = NULL;
+static void* control_user = NULL;
+
+static void btn_event_cb(lv_event_t* e) {
+  ui_command_t cmd = (ui_command_t)(uintptr_t)lv_event_get_user_data(e);
+  if (control_cb) {
+    control_cb(cmd, control_user);
+  }
+}
+
+static lv_obj_t* make_btn(lv_obj_t* parent, const char* symbol,
+                          ui_command_t cmd) {
+  lv_obj_t* btn = lv_button_create(parent);
+  lv_obj_set_size(btn, 56, 44);
+  lv_obj_set_style_bg_color(btn, lv_color_hex(0x2a2a2a), 0);
+  lv_obj_set_style_radius(btn, 8, 0);
+  lv_obj_add_event_cb(btn, btn_event_cb, LV_EVENT_CLICKED,
+                      (void*)(uintptr_t)cmd);
+  lv_obj_t* lbl = lv_label_create(btn);
+  lv_label_set_text(lbl, symbol);
+  lv_obj_center(lbl);
+  return btn;
+}
+
+void ui_init(void) {
+  lvgl_port_lock(0);
+
+  lv_obj_t* scr = lv_screen_active();
+  lv_obj_set_style_bg_color(scr, lv_color_hex(0x101418), 0);
+  lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+  lv_obj_clear_flag(scr, LV_OBJ_FLAG_SCROLLABLE);
+
+  // --- Zona sensor ---
+  lbl_temp = lv_label_create(scr);
+  lv_obj_set_style_text_font(lbl_temp, &lv_font_montserrat_48, 0);
+  lv_obj_set_style_text_color(lbl_temp, lv_color_hex(0xffffff), 0);
+  lv_label_set_text(lbl_temp, "--.-\xC2\xB0""C");
+  lv_obj_align(lbl_temp, LV_ALIGN_TOP_MID, 0, 24);
+
+  lbl_hum = lv_label_create(scr);
+  lv_obj_set_style_text_font(lbl_hum, &lv_font_montserrat_28, 0);
+  lv_obj_set_style_text_color(lbl_hum, lv_color_hex(0x7ec8e3), 0);
+  lv_label_set_text(lbl_hum, LV_SYMBOL_TINT " --%");
+  lv_obj_align(lbl_hum, LV_ALIGN_TOP_MID, 0, 84);
+
+  lbl_status = lv_label_create(scr);
+  lv_obj_set_style_text_font(lbl_status, &lv_font_montserrat_14, 0);
+  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x808080), 0);
+  lv_label_set_text(lbl_status, "Esperando Spotify...");
+  lv_obj_align(lbl_status, LV_ALIGN_TOP_MID, 0, 122);
+
+  // --- Barra Spotify ---
+  lv_obj_t* bar = lv_obj_create(scr);
+  lv_obj_set_size(bar, 320, 96);
+  lv_obj_align(bar, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_obj_set_style_bg_color(bar, lv_color_hex(0x181c22), 0);
+  lv_obj_set_style_border_width(bar, 0, 0);
+  lv_obj_set_style_radius(bar, 0, 0);
+  lv_obj_set_style_pad_all(bar, 6, 0);
+  lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+
+  lbl_title = lv_label_create(bar);
+  lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_16, 0);
+  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0xffffff), 0);
+  lv_label_set_long_mode(lbl_title, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(lbl_title, 308);
+  lv_label_set_text(lbl_title, "-");
+  lv_obj_align(lbl_title, LV_ALIGN_TOP_LEFT, 0, 0);
+
+  lbl_artist = lv_label_create(bar);
+  lv_obj_set_style_text_font(lbl_artist, &lv_font_montserrat_14, 0);
+  lv_obj_set_style_text_color(lbl_artist, lv_color_hex(0x1db954), 0);
+  lv_label_set_long_mode(lbl_artist, LV_LABEL_LONG_DOT);
+  lv_obj_set_width(lbl_artist, 150);
+  lv_label_set_text(lbl_artist, "-");
+  lv_obj_align(lbl_artist, LV_ALIGN_LEFT_MID, 0, 8);
+
+  // Botones prev / play-pausa / next
+  lv_obj_t* btn_prev = make_btn(bar, LV_SYMBOL_PREV, UI_CMD_PREV);
+  lv_obj_align(btn_prev, LV_ALIGN_BOTTOM_RIGHT, -128, 0);
+
+  lv_obj_t* btn_play = make_btn(bar, LV_SYMBOL_PLAY, UI_CMD_PLAY_PAUSE);
+  lv_obj_align(btn_play, LV_ALIGN_BOTTOM_RIGHT, -64, 0);
+  btn_play_label = lv_obj_get_child(btn_play, 0);
+
+  lv_obj_t* btn_next = make_btn(bar, LV_SYMBOL_NEXT, UI_CMD_NEXT);
+  lv_obj_align(btn_next, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+
+  lvgl_port_unlock();
+}
+
+void ui_set_control_cb(ui_control_cb_t cb, void* user) {
+  control_cb = cb;
+  control_user = user;
+}
+
+void ui_set_env(float temp_c, float hum_pct) {
+  if (!lbl_temp) {
+    return;
+  }
+  lvgl_port_lock(0);
+  lv_label_set_text_fmt(lbl_temp, "%.1f\xC2\xB0""C", (double)temp_c);
+  lv_label_set_text_fmt(lbl_hum, LV_SYMBOL_TINT " %.0f%%", (double)hum_pct);
+  lvgl_port_unlock();
+}
+
+void ui_set_track(const char* title, const char* artist) {
+  if (!lbl_title) {
+    return;
+  }
+  lvgl_port_lock(0);
+  lv_label_set_text(lbl_title, title && title[0] ? title : "-");
+  lv_label_set_text(lbl_artist, artist && artist[0] ? artist : "-");
+  lvgl_port_unlock();
+}
+
+void ui_set_playing(bool playing) {
+  if (!btn_play_label) {
+    return;
+  }
+  lvgl_port_lock(0);
+  lv_label_set_text(btn_play_label, playing ? LV_SYMBOL_PAUSE : LV_SYMBOL_PLAY);
+  lvgl_port_unlock();
+}
+
+void ui_set_status(const char* status) {
+  if (!lbl_status) {
+    return;
+  }
+  lvgl_port_lock(0);
+  lv_label_set_text(lbl_status, status);
+  lvgl_port_unlock();
+}

--- a/targets/esp32/main/ui.h
+++ b/targets/esp32/main/ui.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  UI_CMD_PLAY_PAUSE,
+  UI_CMD_NEXT,
+  UI_CMD_PREV,
+} ui_command_t;
+
+typedef void (*ui_control_cb_t)(ui_command_t cmd, void* user);
+
+// Crea la pantalla. Requiere board_display_init() previo.
+void ui_init(void);
+
+// Callback para los botones táctiles (se invoca en la tarea LVGL).
+void ui_set_control_cb(ui_control_cb_t cb, void* user);
+
+// Setters seguros desde cualquier tarea (bloquean LVGL internamente).
+void ui_set_env(float temp_c, float hum_pct);
+void ui_set_track(const char* title, const char* artist);
+void ui_set_playing(bool playing);
+void ui_set_status(const char* status);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/esp32/main/wifi_ui.c
+++ b/targets/esp32/main/wifi_ui.c
@@ -1,0 +1,262 @@
+// Gestor WiFi con portal tactil: escanea redes, pide contraseña con teclado
+// LVGL y guarda credenciales en NVS (namespace "wificfg").
+
+#include "wifi_ui.h"
+
+#include <string.h>
+
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_lvgl_port.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+#include "lvgl.h"
+#include "nvs.h"
+#include "sdkconfig.h"
+#include "ui.h"
+
+#define WIFI_NS "wificfg"
+#define BIT_CONNECTED BIT0
+#define BIT_FAILED BIT1
+#define MAX_RETRIES 5
+
+static const char* TAG = "wifi_ui";
+
+static EventGroupHandle_t eg;
+static bool provisioning = false;
+static int retries = 0;
+static char cur_ssid[33];
+static char cur_pass[65];
+
+static lv_obj_t* scr_prov;
+static lv_obj_t* scr_main;
+static lv_obj_t* net_list;
+static lv_obj_t* ta_pass;
+static lv_obj_t* kb;
+static lv_obj_t* lbl_info;
+
+static void save_creds(void) {
+  nvs_handle_t h;
+  if (nvs_open(WIFI_NS, NVS_READWRITE, &h) == ESP_OK) {
+    nvs_set_str(h, "ssid", cur_ssid);
+    nvs_set_str(h, "pass", cur_pass);
+    nvs_commit(h);
+    nvs_close(h);
+  }
+}
+
+static bool load_creds(void) {
+  nvs_handle_t h;
+  size_t l1 = sizeof(cur_ssid), l2 = sizeof(cur_pass);
+  if (nvs_open(WIFI_NS, NVS_READONLY, &h) != ESP_OK) {
+    return false;
+  }
+  bool ok = nvs_get_str(h, "ssid", cur_ssid, &l1) == ESP_OK &&
+            nvs_get_str(h, "pass", cur_pass, &l2) == ESP_OK;
+  nvs_close(h);
+  return ok && cur_ssid[0];
+}
+
+static void close_provisioning(void) {
+  provisioning = false;
+  lvgl_port_lock(0);
+  if (scr_prov) {
+    lv_screen_load(scr_main);
+    lv_obj_delete(scr_prov);
+    scr_prov = NULL;
+    net_list = NULL;
+    ta_pass = NULL;
+    kb = NULL;
+    lbl_info = NULL;
+  }
+  lvgl_port_unlock();
+  ui_set_status("WiFi conectado");
+}
+
+static void on_wifi_event(void* arg, esp_event_base_t base, int32_t id,
+                          void* data) {
+  if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
+    if (retries < MAX_RETRIES) {
+      retries++;
+      esp_wifi_connect();
+    } else {
+      xEventGroupSetBits(eg, BIT_FAILED);
+      if (provisioning && lbl_info) {
+        lvgl_port_lock(0);
+        lv_label_set_text(lbl_info, "Fallo la conexion, prueba de nuevo");
+        lvgl_port_unlock();
+      }
+    }
+  } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
+    retries = 0;
+    save_creds();
+    xEventGroupSetBits(eg, BIT_CONNECTED);
+    if (provisioning) {
+      close_provisioning();
+    }
+  }
+}
+
+static void try_connect(void) {
+  wifi_config_t wc = {0};
+  strncpy((char*)wc.sta.ssid, cur_ssid, sizeof(wc.sta.ssid) - 1);
+  strncpy((char*)wc.sta.password, cur_pass, sizeof(wc.sta.password) - 1);
+  wc.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+  retries = 0;
+  xEventGroupClearBits(eg, BIT_CONNECTED | BIT_FAILED);
+  esp_wifi_set_config(WIFI_IF_STA, &wc);
+  esp_wifi_disconnect();
+  esp_wifi_connect();
+}
+
+// --- Portal LVGL ---
+
+static void do_connect_from_ui(void) {
+  const char* pass = lv_textarea_get_text(ta_pass);
+  strncpy(cur_pass, pass, sizeof(cur_pass) - 1);
+  cur_pass[sizeof(cur_pass) - 1] = 0;
+  if (!cur_ssid[0]) {
+    lv_label_set_text(lbl_info, "Elige una red de la lista");
+    return;
+  }
+  lv_label_set_text_fmt(lbl_info, "Conectando a %s...", cur_ssid);
+  try_connect();
+}
+
+static void kb_ready_cb(lv_event_t* e) {
+  do_connect_from_ui();
+}
+
+static void net_btn_cb(lv_event_t* e) {
+  lv_obj_t* btn = lv_event_get_target(e);
+  const char* txt = lv_list_get_button_text(net_list, btn);
+  strncpy(cur_ssid, txt, sizeof(cur_ssid) - 1);
+  cur_ssid[sizeof(cur_ssid) - 1] = 0;
+  lv_label_set_text_fmt(lbl_info, "Red: %s — escribe la contraseña", cur_ssid);
+  lv_obj_clear_flag(ta_pass, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(kb, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_state(ta_pass, LV_STATE_FOCUSED);
+}
+
+static void scan_task(void* arg) {
+  wifi_scan_config_t sc = {0};
+  static wifi_ap_record_t recs[20];
+  uint16_t n = 20;
+  esp_err_t err = esp_wifi_scan_start(&sc, true);
+  if (err == ESP_OK) {
+    esp_wifi_scan_get_ap_records(&n, recs);
+  } else {
+    n = 0;
+    ESP_LOGW(TAG, "Scan fallo: %s", esp_err_to_name(err));
+  }
+  lvgl_port_lock(0);
+  if (net_list) {
+    lv_obj_clean(net_list);
+    for (int i = 0; i < n; i++) {
+      if (!recs[i].ssid[0]) {
+        continue;
+      }
+      lv_obj_t* b = lv_list_add_button(net_list, LV_SYMBOL_WIFI,
+                                       (const char*)recs[i].ssid);
+      lv_obj_add_event_cb(b, net_btn_cb, LV_EVENT_CLICKED, NULL);
+    }
+    if (lbl_info) {
+      lv_label_set_text(lbl_info, n ? "Elige tu red"
+                                    : "Sin redes. Reinicia para reintentar");
+    }
+  }
+  lvgl_port_unlock();
+  vTaskDelete(NULL);
+}
+
+// Construye y muestra el portal. Llamar con el lock LVGL tomado.
+static void build_portal_locked(void) {
+  provisioning = true;
+  scr_main = lv_screen_active();
+
+  scr_prov = lv_obj_create(NULL);
+  lv_obj_set_style_bg_color(scr_prov, lv_color_hex(0x101418), 0);
+  lv_obj_set_style_bg_opa(scr_prov, LV_OPA_COVER, 0);
+  lv_obj_clear_flag(scr_prov, LV_OBJ_FLAG_SCROLLABLE);
+
+  lbl_info = lv_label_create(scr_prov);
+  lv_obj_set_style_text_color(lbl_info, lv_color_hex(0xffffff), 0);
+  lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_DOT);
+  lv_obj_set_width(lbl_info, 312);
+  lv_label_set_text(lbl_info, "Buscando redes...");
+  lv_obj_align(lbl_info, LV_ALIGN_TOP_LEFT, 4, 4);
+
+  net_list = lv_list_create(scr_prov);
+  lv_obj_set_size(net_list, 312, 86);
+  lv_obj_align(net_list, LV_ALIGN_TOP_MID, 0, 24);
+  lv_obj_set_style_bg_color(net_list, lv_color_hex(0x181c22), 0);
+
+  ta_pass = lv_textarea_create(scr_prov);
+  lv_textarea_set_one_line(ta_pass, true);
+  lv_textarea_set_password_mode(ta_pass, false);
+  lv_textarea_set_placeholder_text(ta_pass, "Contraseña");
+  lv_obj_set_size(ta_pass, 312, 32);
+  lv_obj_align(ta_pass, LV_ALIGN_TOP_MID, 0, 112);
+  lv_obj_add_flag(ta_pass, LV_OBJ_FLAG_HIDDEN);
+
+  kb = lv_keyboard_create(scr_prov);
+  lv_obj_set_size(kb, 320, 92);
+  lv_obj_align(kb, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_keyboard_set_textarea(kb, ta_pass);
+  lv_obj_add_event_cb(kb, kb_ready_cb, LV_EVENT_READY, NULL);
+  lv_obj_add_flag(kb, LV_OBJ_FLAG_HIDDEN);
+
+  lv_screen_load(scr_prov);
+}
+
+void wifi_ui_open_settings(void) {
+  if (scr_prov) {
+    return;  // ya abierto
+  }
+  build_portal_locked();
+  xTaskCreate(scan_task, "wifi_scan", 4096, NULL, 4, NULL);
+}
+
+void wifi_ui_connect(void) {
+  eg = xEventGroupCreate();
+
+  esp_netif_create_default_wifi_sta();
+  wifi_init_config_t init_cfg = WIFI_INIT_CONFIG_DEFAULT();
+  ESP_ERROR_CHECK(esp_wifi_init(&init_cfg));
+  ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                             on_wifi_event, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                             on_wifi_event, NULL));
+  ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_start());
+  esp_wifi_set_ps(WIFI_PS_NONE);
+
+  if (!load_creds()) {
+    strncpy(cur_ssid, CONFIG_EXAMPLE_WIFI_SSID, sizeof(cur_ssid) - 1);
+    strncpy(cur_pass, CONFIG_EXAMPLE_WIFI_PASSWORD, sizeof(cur_pass) - 1);
+  }
+
+  if (cur_ssid[0]) {
+    try_connect();
+    EventBits_t bits = xEventGroupWaitBits(eg, BIT_CONNECTED | BIT_FAILED,
+                                           pdFALSE, pdFALSE,
+                                           pdMS_TO_TICKS(20000));
+    if (bits & BIT_CONNECTED) {
+      return;
+    }
+  }
+
+  // Sin credenciales validas: portal tactil
+  ESP_LOGW(TAG, "Abriendo portal de configuracion WiFi");
+  ui_set_status("Configura el WiFi en pantalla");
+  lvgl_port_lock(0);
+  if (!scr_prov) {
+    build_portal_locked();
+  }
+  lvgl_port_unlock();
+  xTaskCreate(scan_task, "wifi_scan", 4096, NULL, 4, NULL);
+
+  xEventGroupWaitBits(eg, BIT_CONNECTED, pdFALSE, pdFALSE, portMAX_DELAY);
+}

--- a/targets/esp32/main/wifi_ui.h
+++ b/targets/esp32/main/wifi_ui.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Conecta WiFi (bloqueante). Usa credenciales guardadas en NVS o las de
+// sdkconfig; si fallan, muestra el portal tactil de seleccion de red y
+// espera hasta lograr conexion. Requiere ui_init() previo.
+void wifi_ui_connect(void);
+
+// Abre el portal de seleccion de red (llamar desde la tarea LVGL).
+void wifi_ui_open_settings(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/esp32/partitions.csv
+++ b/targets/esp32/partitions.csv
@@ -2,5 +2,5 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 2M,
+factory,  app,  factory, 0x10000, 4M,
 storage,  data, spiffs,  ,        1M,


### PR DESCRIPTION
## What

Single firmware for the LCDWIKI 2.8" IPS ESP32-S3 board (ES3C28P/ES3N28P V1.0) combining Spotify Connect (cspot) with an LVGL 9 status screen and an SHT31-D environment sensor, in `targets/esp32`.

- **board_display.c/h** — ILI9341V over SPI2 @ 40 MHz via `esp_lcd` + `esp_lvgl_port`, landscape 320x240 (BGR, inverted colors, matching the vendor demo's MADCTL 0x28), FT6336G touch through the `esp_lcd_touch_ft5x06` driver (I2C polling, no INT).
- **ui.c/h** — temperature/humidity readout, status line, bottom Spotify bar with scrolling track title, artist, and prev/play-pause/next touch buttons.
- **sht31.c/h** — task reading the SHT31-D every 5 s on the shared I2C bus (single-shot high repeatability, Sensirion CRC-8), publishing to the UI.
- **main.cpp** — display/UI/sensor brought up before Wi-Fi; `SpircHandler` events (TRACK_INFO, PLAY_PAUSE, PLAYBACK_START, DISC) wired to the UI; touch buttons drive `setPause`/`nextSong`/`previousSong`.
- **partitions.csv** — factory app partition grown 2M -> 4M (binary is ~2.3 MB with LVGL).
- **idf_component.yml** — adds `lvgl ^9.2`, `esp_lvgl_port ^2.4`, `esp_lcd_ili9341 ^2`, `esp_lcd_touch_ft5x06 ^1`.

## Why

Turns the cspot ESP32-S3 target into a small smart display: Spotify playback status/control plus room temperature and humidity on one device.

## Reviewer notes

- The LCD, touch, ES8311 codec and SHT31 share legacy I2C0 (SDA=16, SCL=15). `board_display_init()` installs the driver once; this needs a companion change in the **bell** submodule so `Es8311Init`'s `I2cInit` tolerates an already-installed driver instead of failing (not included here — bell is a separate repo).
- Built and size-checked with ESP-IDF v5.3.3 for esp32s3 (`idf.py build` passes). On-device verification of display orientation and touch mapping is pending.
- `dependencies.lock` is included for reproducible managed-component resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)